### PR TITLE
Redesign site with compact index style

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -8,3 +8,4 @@ public/.gitkeep
 Sessions/**/*.md
 Sessions/**/*.pdf
 src/data/release-1/fixture-store.ts
+design-*.html

--- a/design-board.html
+++ b/design-board.html
@@ -1,0 +1,536 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>SessionBook — Design Board</title>
+<style>
+/* ─── Design Board Chrome ─── */
+*{box-sizing:border-box;margin:0;padding:0}
+body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;background:#18181b;color:#e4e4e7;min-height:100vh}
+.board-header{padding:2.5rem 2rem 1.5rem;max-width:90rem;margin:0 auto}
+.board-header h1{font-size:2rem;font-weight:800;letter-spacing:-.02em;color:#fff}
+.board-header p{color:#a1a1aa;margin-top:.5rem;max-width:56rem;line-height:1.6}
+.board-nav{display:flex;flex-wrap:wrap;gap:.5rem;margin-top:1.25rem}
+.board-nav a{padding:.5rem 1rem;border-radius:999px;font-size:.85rem;font-weight:600;color:#a1a1aa;background:#27272a;border:1px solid #3f3f46;text-decoration:none;transition:all .15s}
+.board-nav a:hover,.board-nav a.active{background:#3f3f46;color:#fff}
+
+.design-section{max-width:90rem;margin:0 auto;padding:2rem}
+.design-section+.design-section{border-top:1px solid #27272a}
+.section-label{font-size:.75rem;font-weight:700;text-transform:uppercase;letter-spacing:.1em;color:#71717a;margin-bottom:.5rem}
+.section-title{font-size:1.5rem;font-weight:700;color:#fff;margin-bottom:.25rem}
+.section-desc{color:#a1a1aa;max-width:48rem;line-height:1.6;margin-bottom:1.5rem}
+.section-link{display:inline-flex;align-items:center;gap:.35rem;color:#60a5fa;font-weight:600;font-size:.9rem;text-decoration:none;margin-top:.75rem;transition:color .15s}
+.section-link:hover{color:#93bbfd}
+.section-link svg{width:16px;height:16px}
+
+/* ─── Swatches ─── */
+.palette-row{display:flex;gap:.75rem;flex-wrap:wrap;margin-bottom:1.5rem}
+.swatch{width:5rem;text-align:center}
+.swatch-color{width:5rem;height:3.5rem;border-radius:.75rem;border:1px solid rgba(255,255,255,.08)}
+.swatch-label{font-size:.65rem;margin-top:.35rem;color:#a1a1aa}
+
+/* ─── Side-by-side previews ─── */
+.preview-row{display:grid;grid-template-columns:repeat(auto-fit,minmax(22rem,1fr));gap:1.5rem}
+
+/* ─── Tune Card Previews (all self-contained) ─── */
+.card-frame{border-radius:1rem;overflow:hidden;border:1px solid #3f3f46;background:#27272a}
+.card-frame__label{padding:.75rem 1rem;font-size:.7rem;font-weight:700;text-transform:uppercase;letter-spacing:.08em;color:#71717a;border-bottom:1px solid #3f3f46}
+.card-frame__body{padding:0}
+
+/* ─── Option A: Current (warm serif) ─── */
+.opt-a{font-family:Georgia,'Times New Roman',serif;background:#f8f5f1;color:#1f1b18;padding:1.5rem;border-radius:0 0 1rem 1rem}
+.opt-a .badge{color:#2f5d46;font-size:.8rem;font-weight:700;text-transform:uppercase;letter-spacing:.08em}
+.opt-a h3{font-size:1.3rem;margin:.25rem 0 .5rem}
+.opt-a .meta{color:#6f6459;font-size:.88rem;line-height:1.5}
+.opt-a .meta strong{color:#1f1b18}
+.opt-a .chart{margin-top:.75rem;padding:.75rem;background:#f2ece4;border:1px solid #ded3c5;border-radius:.75rem;font-family:ui-monospace,SFMono-Regular,Menlo,Monaco,monospace;font-size:.8rem;line-height:1.5;white-space:pre-wrap;color:#1f1b18}
+.opt-a .tags{display:flex;flex-wrap:wrap;gap:.35rem;margin-top:.65rem}
+.opt-a .tag{background:#e8e0d4;color:#6f6459;padding:.2rem .55rem;border-radius:999px;font-size:.72rem;font-weight:600}
+
+/* ─── Option B: Clean modern (system sans) ─── */
+.opt-b{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;background:#ffffff;color:#111827;padding:1.5rem;border-radius:0 0 1rem 1rem}
+.opt-b .tune-header{display:flex;align-items:baseline;gap:.75rem;margin-bottom:.5rem}
+.opt-b .tune-type{font-size:.7rem;font-weight:700;text-transform:uppercase;letter-spacing:.06em;padding:.2rem .55rem;border-radius:999px;background:#ecfdf5;color:#059669}
+.opt-b .tune-key{font-size:.7rem;font-weight:600;padding:.2rem .55rem;border-radius:999px;background:#eff6ff;color:#2563eb}
+.opt-b h3{font-size:1.15rem;font-weight:700;margin:0}
+.opt-b .summary{color:#6b7280;font-size:.88rem;line-height:1.5;margin:.35rem 0}
+.opt-b .detail-row{display:flex;flex-wrap:wrap;gap:.5rem;margin-top:.5rem}
+.opt-b .detail-chip{font-size:.75rem;color:#374151;background:#f3f4f6;padding:.25rem .6rem;border-radius:.5rem}
+.opt-b .chart{margin-top:.75rem;padding:.75rem;background:#f9fafb;border:1px solid #e5e7eb;border-radius:.5rem;font-family:ui-monospace,SFMono-Regular,Menlo,Monaco,monospace;font-size:.8rem;line-height:1.5;white-space:pre-wrap;color:#1f2937}
+
+/* ─── Option C: Dark & warm ─── */
+.opt-c{font-family:Georgia,'Times New Roman',serif;background:#1c1917;color:#e7e5e4;padding:1.5rem;border-radius:0 0 1rem 1rem}
+.opt-c .badge{font-size:.75rem;font-weight:700;text-transform:uppercase;letter-spacing:.08em;color:#a3e635}
+.opt-c h3{font-size:1.25rem;margin:.25rem 0 .4rem;color:#fafaf9}
+.opt-c .meta{color:#a8a29e;font-size:.88rem;line-height:1.5}
+.opt-c .meta strong{color:#d6d3d1}
+.opt-c .chart{margin-top:.75rem;padding:.75rem;background:#292524;border:1px solid #44403c;border-radius:.75rem;font-family:ui-monospace,SFMono-Regular,Menlo,Monaco,monospace;font-size:.8rem;line-height:1.5;white-space:pre-wrap;color:#d6d3d1}
+.opt-c .tags{display:flex;flex-wrap:wrap;gap:.35rem;margin-top:.65rem}
+.opt-c .tag{background:#292524;color:#a8a29e;padding:.2rem .55rem;border-radius:999px;font-size:.72rem;font-weight:600;border:1px solid #44403c}
+
+/* ─── Option D: Acoustic / editorial ─── */
+.opt-d{font-family:'Iowan Old Style',Palatino,'Palatino Linotype','Book Antiqua',serif;background:#fdfcfa;color:#292524;padding:1.75rem;border-radius:0 0 1rem 1rem;border-top:3px solid #b45309}
+.opt-d .tune-label{font-size:.7rem;font-weight:600;text-transform:uppercase;letter-spacing:.1em;color:#b45309;margin-bottom:.25rem}
+.opt-d h3{font-size:1.35rem;font-weight:400;font-style:italic;margin:0 0 .35rem}
+.opt-d .subtitle{font-size:.88rem;color:#78716c;margin-bottom:.5rem}
+.opt-d .divider{height:1px;background:#e7e5e4;margin:.65rem 0}
+.opt-d .chart{padding:.75rem;background:#faf5ee;border-left:3px solid #d4a854;font-family:ui-monospace,SFMono-Regular,Menlo,Monaco,monospace;font-size:.82rem;line-height:1.55;white-space:pre-wrap;color:#44403c}
+.opt-d .set-note{font-size:.8rem;color:#a8a29e;font-style:italic;margin-top:.65rem}
+
+/* ─── Option E: Compact index / table feel ─── */
+.opt-e{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;background:#ffffff;color:#111827;padding:0;border-radius:0 0 1rem 1rem;overflow:hidden}
+.opt-e .row{display:grid;grid-template-columns:2.5rem 1fr auto;align-items:center;gap:.75rem;padding:.85rem 1rem;border-bottom:1px solid #f3f4f6;transition:background .1s}
+.opt-e .row:hover{background:#f9fafb}
+.opt-e .row:last-child{border-bottom:0}
+.opt-e .row-icon{width:2.5rem;height:2.5rem;border-radius:.5rem;display:flex;align-items:center;justify-content:center;font-size:.75rem;font-weight:800;text-transform:uppercase}
+.opt-e .row-icon.jig{background:#fef3c7;color:#92400e}
+.opt-e .row-icon.reel{background:#dbeafe;color:#1e40af}
+.opt-e .row-icon.hornpipe{background:#fce7f3;color:#9d174d}
+.opt-e .row-icon.polka{background:#d1fae5;color:#065f46}
+.opt-e .row-body h3{font-size:.95rem;font-weight:600;margin:0 0 .15rem}
+.opt-e .row-body .sub{font-size:.78rem;color:#6b7280}
+.opt-e .row-meta{font-size:.78rem;color:#9ca3af;text-align:right;white-space:nowrap}
+
+/* ─── Option F: Music-paper inspired ─── */
+.opt-f{font-family:'Courier New',Courier,monospace;background:#fffef7;color:#1a1a1a;padding:1.5rem;border-radius:0 0 1rem 1rem;background-image:repeating-linear-gradient(transparent,transparent 1.45rem,#e8e4d8 1.45rem,#e8e4d8 1.5rem)}
+.opt-f .tune-stamp{display:inline-block;font-size:.65rem;font-weight:700;text-transform:uppercase;letter-spacing:.12em;border:2px solid #8b5e3c;color:#8b5e3c;padding:.15rem .45rem;margin-bottom:.4rem}
+.opt-f h3{font-size:1.15rem;font-weight:700;margin:0 0 .25rem}
+.opt-f .info{font-size:.82rem;color:#555;line-height:1.55}
+.opt-f .chart{margin-top:.65rem;padding:.65rem;border:1px dashed #c9b99a;font-size:.82rem;line-height:1.55;white-space:pre-wrap;background:rgba(255,255,240,.6)}
+
+/* ─── Full-page link cards ─── */
+.fullpage-grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(18rem,1fr));gap:1rem;margin-top:1.5rem}
+.fullpage-card{background:#27272a;border:1px solid #3f3f46;border-radius:1rem;padding:1.5rem;transition:all .15s;text-decoration:none;color:inherit;display:block}
+.fullpage-card:hover{background:#3f3f46;border-color:#52525b;transform:translateY(-2px)}
+.fullpage-card h3{color:#fff;font-size:1.1rem;margin-bottom:.35rem}
+.fullpage-card p{color:#a1a1aa;font-size:.88rem;line-height:1.5}
+.fullpage-card .arrow{color:#60a5fa;font-size:.85rem;font-weight:600;margin-top:.75rem;display:block}
+</style>
+</head>
+<body>
+
+<!-- ═══════════════════════════════════════════
+     BOARD HEADER
+     ═══════════════════════════════════════════ -->
+<div class="board-header">
+  <h1>SessionBook — Design Board</h1>
+  <p>
+    Six design directions for SessionBook's look and feel. Each section shows a tune card treatment.
+    Below the card comparisons, click through to full-page mockups of each direction applied to the homepage and tune index.
+  </p>
+  <nav class="board-nav">
+    <a href="#cards">Tune Cards</a>
+    <a href="#palettes">Color Palettes</a>
+    <a href="#fullpages">Full Pages ↗</a>
+  </nav>
+</div>
+
+<!-- ═══════════════════════════════════════════
+     SECTION 1: TUNE CARD COMPARISON
+     ═══════════════════════════════════════════ -->
+<section class="design-section" id="cards">
+  <div class="section-label">Tune Card Treatments</div>
+  <div class="section-title">Side-by-side card designs</div>
+  <p class="section-desc">
+    Same tune data, six visual directions. Each represents a distinct personality for the site:
+    the current warm serif, a clean modern take, a dark mode, an editorial/acoustic feel,
+    a compact index row, and a music-paper aesthetic.
+  </p>
+
+  <div class="preview-row">
+
+    <!-- A: Current -->
+    <div class="card-frame">
+      <div class="card-frame__label">A — Current: Warm Serif</div>
+      <div class="card-frame__body">
+        <div class="opt-a">
+          <span class="badge">Jig</span>
+          <h3>Morrison's Jig</h3>
+          <div class="meta">
+            <p><strong>Chart:</strong> Morrison's Jig (standard) in Em Dorian (6/8)</p>
+            <p><strong>Sets:</strong> Jig Set 1, First Friday December</p>
+            <p><strong>Aliases:</strong> Morrison's</p>
+          </div>
+          <div class="chart">| Em / / / | / / D / | Em / / / | C / D / |
+| Em / / / | / / D / | Em / / / | C / D / |
+| Em / / / | / / D / | C  / / / | D / / / |</div>
+          <div class="tags">
+            <span class="tag">Em</span>
+            <span class="tag">Dorian</span>
+            <span class="tag">6/8</span>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- B: Clean modern -->
+    <div class="card-frame">
+      <div class="card-frame__label">B — Clean Modern</div>
+      <div class="card-frame__body">
+        <div class="opt-b">
+          <div class="tune-header">
+            <h3>Morrison's Jig</h3>
+            <span class="tune-type">Jig</span>
+            <span class="tune-key">Em</span>
+          </div>
+          <p class="summary">A classic session jig in Em. Appears in Jig Set 1 and First Friday December.</p>
+          <div class="detail-row">
+            <span class="detail-chip">Dorian</span>
+            <span class="detail-chip">6/8</span>
+            <span class="detail-chip">aka Morrison's</span>
+          </div>
+          <div class="chart">| Em / / / | / / D / | Em / / / | C / D / |
+| Em / / / | / / D / | Em / / / | C / D / |
+| Em / / / | / / D / | C  / / / | D / / / |</div>
+        </div>
+      </div>
+    </div>
+
+    <!-- C: Dark & warm -->
+    <div class="card-frame">
+      <div class="card-frame__label">C — Dark &amp; Warm</div>
+      <div class="card-frame__body">
+        <div class="opt-c">
+          <span class="badge">Jig</span>
+          <h3>Morrison's Jig</h3>
+          <div class="meta">
+            <p><strong>Chart:</strong> Morrison's Jig (standard) · Em Dorian · 6/8</p>
+            <p><strong>Sets:</strong> Jig Set 1, First Friday December</p>
+          </div>
+          <div class="chart">| Em / / / | / / D / | Em / / / | C / D / |
+| Em / / / | / / D / | Em / / / | C / D / |
+| Em / / / | / / D / | C  / / / | D / / / |</div>
+          <div class="tags">
+            <span class="tag">Em</span>
+            <span class="tag">Dorian</span>
+            <span class="tag">6/8</span>
+            <span class="tag">Morrison's</span>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- D: Acoustic / editorial -->
+    <div class="card-frame">
+      <div class="card-frame__label">D — Acoustic / Editorial</div>
+      <div class="card-frame__body">
+        <div class="opt-d">
+          <div class="tune-label">Jig · Em Dorian · 6/8</div>
+          <h3>Morrison's Jig</h3>
+          <div class="subtitle">Also known as Morrison's · In Jig Set 1, First Friday December</div>
+          <div class="divider"></div>
+          <div class="chart">| Em / / / | / / D / | Em / / / | C / D / |
+| Em / / / | / / D / | Em / / / | C / D / |
+| Em / / / | / / D / | C  / / / | D / / / |</div>
+          <div class="set-note">↳ Jig Set 1 · First Friday December</div>
+        </div>
+      </div>
+    </div>
+
+    <!-- E: Compact index -->
+    <div class="card-frame">
+      <div class="card-frame__label">E — Compact Index</div>
+      <div class="card-frame__body">
+        <div class="opt-e">
+          <div class="row">
+            <div class="row-icon jig">Jig</div>
+            <div class="row-body">
+              <h3>Morrison's Jig</h3>
+              <span class="sub">Morrison's · Jig Set 1, First Friday December</span>
+            </div>
+            <div class="row-meta">Em Dorian<br>6/8</div>
+          </div>
+          <div class="row">
+            <div class="row-icon jig">Jig</div>
+            <div class="row-body">
+              <h3>The Butterfly</h3>
+              <span class="sub">Jig Set 1</span>
+            </div>
+            <div class="row-meta">Em Dorian<br>6/8</div>
+          </div>
+          <div class="row">
+            <div class="row-icon jig">Jig</div>
+            <div class="row-body">
+              <h3>Swallowtail Jig</h3>
+              <span class="sub">Jig Set 1</span>
+            </div>
+            <div class="row-meta">Em Dorian<br>6/8</div>
+          </div>
+          <div class="row">
+            <div class="row-icon reel">Reel</div>
+            <div class="row-body">
+              <h3>The Green Mountain</h3>
+              <span class="sub">Reel Set 1</span>
+            </div>
+            <div class="row-meta">D Major<br>4/4</div>
+          </div>
+          <div class="row">
+            <div class="row-icon reel">Reel</div>
+            <div class="row-body">
+              <h3>Wind that Shakes the Barley</h3>
+              <span class="sub">Reel Set 1</span>
+            </div>
+            <div class="row-meta">D Major<br>4/4</div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- F: Music paper -->
+    <div class="card-frame">
+      <div class="card-frame__label">F — Music Paper</div>
+      <div class="card-frame__body">
+        <div class="opt-f">
+          <span class="tune-stamp">Jig — Em</span>
+          <h3>Morrison's Jig</h3>
+          <div class="info">
+            Standard chart · Dorian mode · 6/8<br>
+            Sets: Jig Set 1, First Friday December
+          </div>
+          <div class="chart">| Em / / / | / / D / | Em / / / | C / D / |
+| Em / / / | / / D / | Em / / / | C / D / |
+| Em / / / | / / D / | C  / / / | D / / / |</div>
+        </div>
+      </div>
+    </div>
+
+  </div>
+</section>
+
+<!-- ═══════════════════════════════════════════
+     SECTION 2: SECOND TUNE — THE BUTTERFLY
+     ═══════════════════════════════════════════ -->
+<section class="design-section">
+  <div class="section-label">Second Tune Comparison</div>
+  <div class="section-title">The Butterfly — across all treatments</div>
+  <p class="section-desc">
+    Seeing a second tune helps judge consistency. The Butterfly has two parts with different chord patterns.
+  </p>
+
+  <div class="preview-row">
+
+    <div class="card-frame">
+      <div class="card-frame__label">A — Current: Warm Serif</div>
+      <div class="card-frame__body">
+        <div class="opt-a">
+          <span class="badge">Jig</span>
+          <h3>The Butterfly</h3>
+          <div class="meta">
+            <p><strong>Chart:</strong> The Butterfly (standard) in Em Dorian (6/8)</p>
+            <p><strong>Sets:</strong> Jig Set 1</p>
+          </div>
+          <div class="chart">|  Em  /  /  |  /  /  D  |  Em  /  /  |  D  /  /  |
+|  Am  /  /  |  /  /  Bm  |  Am  /  /  |  /  /  Bm |
+|  Em  /  /  |  / / / | D  /  /  |  / / / |
+|  C   /  /  |  / / / | Bm /  /  |  / / / |</div>
+          <div class="tags">
+            <span class="tag">Em</span>
+            <span class="tag">Dorian</span>
+            <span class="tag">6/8</span>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div class="card-frame">
+      <div class="card-frame__label">B — Clean Modern</div>
+      <div class="card-frame__body">
+        <div class="opt-b">
+          <div class="tune-header">
+            <h3>The Butterfly</h3>
+            <span class="tune-type">Jig</span>
+            <span class="tune-key">Em</span>
+          </div>
+          <p class="summary">A beloved slip jig with two distinct parts. Part of Jig Set 1.</p>
+          <div class="detail-row">
+            <span class="detail-chip">Dorian</span>
+            <span class="detail-chip">6/8</span>
+          </div>
+          <div class="chart">|  Em  /  /  |  /  /  D  |  Em  /  /  |  D  /  /  |
+|  Am  /  /  |  /  /  Bm  |  Am  /  /  |  /  /  Bm |
+|  Em  /  /  |  / / / | D  /  /  |  / / / |
+|  C   /  /  |  / / / | Bm /  /  |  / / / |</div>
+        </div>
+      </div>
+    </div>
+
+    <div class="card-frame">
+      <div class="card-frame__label">C — Dark &amp; Warm</div>
+      <div class="card-frame__body">
+        <div class="opt-c">
+          <span class="badge">Jig</span>
+          <h3>The Butterfly</h3>
+          <div class="meta">
+            <p><strong>Chart:</strong> The Butterfly (standard) · Em Dorian · 6/8</p>
+            <p><strong>Sets:</strong> Jig Set 1</p>
+          </div>
+          <div class="chart">|  Em  /  /  |  /  /  D  |  Em  /  /  |  D  /  /  |
+|  Am  /  /  |  /  /  Bm  |  Am  /  /  |  /  /  Bm |
+|  Em  /  /  |  / / / | D  /  /  |  / / / |
+|  C   /  /  |  / / / | Bm /  /  |  / / / |</div>
+          <div class="tags">
+            <span class="tag">Em</span>
+            <span class="tag">Dorian</span>
+            <span class="tag">6/8</span>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div class="card-frame">
+      <div class="card-frame__label">D — Acoustic / Editorial</div>
+      <div class="card-frame__body">
+        <div class="opt-d">
+          <div class="tune-label">Jig · Em Dorian · 6/8</div>
+          <h3>The Butterfly</h3>
+          <div class="subtitle">In Jig Set 1</div>
+          <div class="divider"></div>
+          <div class="chart">|  Em  /  /  |  /  /  D  |  Em  /  /  |  D  /  /  |
+|  Am  /  /  |  /  /  Bm  |  Am  /  /  |  /  /  Bm |
+|  Em  /  /  |  / / / | D  /  /  |  / / / |
+|  C   /  /  |  / / / | Bm /  /  |  / / / |</div>
+          <div class="set-note">↳ Jig Set 1</div>
+        </div>
+      </div>
+    </div>
+
+    <div class="card-frame">
+      <div class="card-frame__label">F — Music Paper</div>
+      <div class="card-frame__body">
+        <div class="opt-f">
+          <span class="tune-stamp">Jig — Em</span>
+          <h3>The Butterfly</h3>
+          <div class="info">
+            Standard chart · Dorian mode · 6/8<br>
+            Sets: Jig Set 1
+          </div>
+          <div class="chart">|  Em  /  /  |  /  /  D  |  Em  /  /  |  D  /  /  |
+|  Am  /  /  |  /  /  Bm  |  Am  /  /  |  /  /  Bm |
+|  Em  /  /  |  / / / | D  /  /  |  / / / |
+|  C   /  /  |  / / / | Bm /  /  |  / / / |</div>
+        </div>
+      </div>
+    </div>
+
+  </div>
+</section>
+
+
+<!-- ═══════════════════════════════════════════
+     SECTION 3: COLOR PALETTES
+     ═══════════════════════════════════════════ -->
+<section class="design-section" id="palettes">
+  <div class="section-label">Color Palettes</div>
+  <div class="section-title">Palette directions</div>
+  <p class="section-desc">
+    The current palette (A) is warm and earthy. Here are the alternatives alongside it.
+  </p>
+
+  <!-- A -->
+  <p style="color:#fff;font-weight:700;margin-bottom:.5rem">A — Warm Parchment (Current)</p>
+  <div class="palette-row">
+    <div class="swatch"><div class="swatch-color" style="background:#f8f5f1"></div><div class="swatch-label">Background<br>#f8f5f1</div></div>
+    <div class="swatch"><div class="swatch-color" style="background:#ffffff"></div><div class="swatch-label">Surface<br>#ffffff</div></div>
+    <div class="swatch"><div class="swatch-color" style="background:#1f1b18"></div><div class="swatch-label">Text<br>#1f1b18</div></div>
+    <div class="swatch"><div class="swatch-color" style="background:#6f6459"></div><div class="swatch-label">Muted<br>#6f6459</div></div>
+    <div class="swatch"><div class="swatch-color" style="background:#ded3c5"></div><div class="swatch-label">Border<br>#ded3c5</div></div>
+    <div class="swatch"><div class="swatch-color" style="background:#2f5d46"></div><div class="swatch-label">Accent<br>#2f5d46</div></div>
+    <div class="swatch"><div class="swatch-color" style="background:#214332"></div><div class="swatch-label">Accent Strong<br>#214332</div></div>
+  </div>
+
+  <!-- B -->
+  <p style="color:#fff;font-weight:700;margin-bottom:.5rem">B — Clean Slate</p>
+  <div class="palette-row">
+    <div class="swatch"><div class="swatch-color" style="background:#f9fafb"></div><div class="swatch-label">Background<br>#f9fafb</div></div>
+    <div class="swatch"><div class="swatch-color" style="background:#ffffff"></div><div class="swatch-label">Surface<br>#ffffff</div></div>
+    <div class="swatch"><div class="swatch-color" style="background:#111827"></div><div class="swatch-label">Text<br>#111827</div></div>
+    <div class="swatch"><div class="swatch-color" style="background:#6b7280"></div><div class="swatch-label">Muted<br>#6b7280</div></div>
+    <div class="swatch"><div class="swatch-color" style="background:#e5e7eb"></div><div class="swatch-label">Border<br>#e5e7eb</div></div>
+    <div class="swatch"><div class="swatch-color" style="background:#059669"></div><div class="swatch-label">Accent<br>#059669</div></div>
+    <div class="swatch"><div class="swatch-color" style="background:#2563eb"></div><div class="swatch-label">Key badge<br>#2563eb</div></div>
+  </div>
+
+  <!-- C -->
+  <p style="color:#fff;font-weight:700;margin-bottom:.5rem">C — Dark &amp; Warm</p>
+  <div class="palette-row">
+    <div class="swatch"><div class="swatch-color" style="background:#1c1917"></div><div class="swatch-label">Background<br>#1c1917</div></div>
+    <div class="swatch"><div class="swatch-color" style="background:#292524"></div><div class="swatch-label">Surface<br>#292524</div></div>
+    <div class="swatch"><div class="swatch-color" style="background:#e7e5e4"></div><div class="swatch-label">Text<br>#e7e5e4</div></div>
+    <div class="swatch"><div class="swatch-color" style="background:#a8a29e"></div><div class="swatch-label">Muted<br>#a8a29e</div></div>
+    <div class="swatch"><div class="swatch-color" style="background:#44403c"></div><div class="swatch-label">Border<br>#44403c</div></div>
+    <div class="swatch"><div class="swatch-color" style="background:#a3e635"></div><div class="swatch-label">Accent<br>#a3e635</div></div>
+    <div class="swatch"><div class="swatch-color" style="background:#fafaf9"></div><div class="swatch-label">Heading<br>#fafaf9</div></div>
+  </div>
+
+  <!-- D -->
+  <p style="color:#fff;font-weight:700;margin-bottom:.5rem">D — Acoustic Amber</p>
+  <div class="palette-row">
+    <div class="swatch"><div class="swatch-color" style="background:#fdfcfa"></div><div class="swatch-label">Background<br>#fdfcfa</div></div>
+    <div class="swatch"><div class="swatch-color" style="background:#faf5ee"></div><div class="swatch-label">Chart bg<br>#faf5ee</div></div>
+    <div class="swatch"><div class="swatch-color" style="background:#292524"></div><div class="swatch-label">Text<br>#292524</div></div>
+    <div class="swatch"><div class="swatch-color" style="background:#78716c"></div><div class="swatch-label">Muted<br>#78716c</div></div>
+    <div class="swatch"><div class="swatch-color" style="background:#e7e5e4"></div><div class="swatch-label">Divider<br>#e7e5e4</div></div>
+    <div class="swatch"><div class="swatch-color" style="background:#b45309"></div><div class="swatch-label">Accent<br>#b45309</div></div>
+    <div class="swatch"><div class="swatch-color" style="background:#d4a854"></div><div class="swatch-label">Gold edge<br>#d4a854</div></div>
+  </div>
+
+  <!-- F -->
+  <p style="color:#fff;font-weight:700;margin-bottom:.5rem">F — Manuscript</p>
+  <div class="palette-row">
+    <div class="swatch"><div class="swatch-color" style="background:#fffef7"></div><div class="swatch-label">Background<br>#fffef7</div></div>
+    <div class="swatch"><div class="swatch-color" style="background:#e8e4d8"></div><div class="swatch-label">Line rule<br>#e8e4d8</div></div>
+    <div class="swatch"><div class="swatch-color" style="background:#1a1a1a"></div><div class="swatch-label">Text<br>#1a1a1a</div></div>
+    <div class="swatch"><div class="swatch-color" style="background:#555555"></div><div class="swatch-label">Info<br>#555555</div></div>
+    <div class="swatch"><div class="swatch-color" style="background:#c9b99a"></div><div class="swatch-label">Dashed bdr<br>#c9b99a</div></div>
+    <div class="swatch"><div class="swatch-color" style="background:#8b5e3c"></div><div class="swatch-label">Accent<br>#8b5e3c</div></div>
+  </div>
+</section>
+
+
+<!-- ═══════════════════════════════════════════
+     SECTION 4: FULL-PAGE MOCKUP LINKS
+     ═══════════════════════════════════════════ -->
+<section class="design-section" id="fullpages">
+  <div class="section-label">Full-Page Mockups</div>
+  <div class="section-title">Click through to see each direction as a full homepage</div>
+  <p class="section-desc">
+    Each page shows the complete homepage and a sample tune index, so you can feel the direction at full scale.
+  </p>
+
+  <div class="fullpage-grid">
+    <a class="fullpage-card" href="design-option-a.html">
+      <h3>A — Warm Serif (Current)</h3>
+      <p>The existing design: Georgia serif, warm beige, sage green accents. Parchment & pub feel.</p>
+      <span class="arrow">View full page →</span>
+    </a>
+    <a class="fullpage-card" href="design-option-b.html">
+      <h3>B — Clean Modern</h3>
+      <p>System sans-serif, cool grays, green & blue badges. Feels like a well-made tool.</p>
+      <span class="arrow">View full page →</span>
+    </a>
+    <a class="fullpage-card" href="design-option-c.html">
+      <h3>C — Dark &amp; Warm</h3>
+      <p>Dark stone backgrounds, warm grays, lime accent. Night-session vibes.</p>
+      <span class="arrow">View full page →</span>
+    </a>
+    <a class="fullpage-card" href="design-option-d.html">
+      <h3>D — Acoustic / Editorial</h3>
+      <p>Palatino serif, amber accent, gold chart borders. Reads like a music journal.</p>
+      <span class="arrow">View full page →</span>
+    </a>
+    <a class="fullpage-card" href="design-option-e.html">
+      <h3>E — Compact Index</h3>
+      <p>Dense table-style rows with type-coded badges. Optimized for browsing large catalogs.</p>
+      <span class="arrow">View full page →</span>
+    </a>
+    <a class="fullpage-card" href="design-option-f.html">
+      <h3>F — Music Paper</h3>
+      <p>Courier mono, lined background, stamp badges. Handwritten notebook aesthetic.</p>
+      <span class="arrow">View full page →</span>
+    </a>
+  </div>
+</section>
+
+</body>
+</html>

--- a/design-option-a.html
+++ b/design-option-a.html
@@ -1,0 +1,509 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>SessionBook — Option A: Warm Serif (Current)</title>
+<style>
+  /* ── Reset ── */
+  *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+  /* ── Design Tokens ── */
+  :root {
+    --font:        Georgia, 'Times New Roman', serif;
+    --bg:          radial-gradient(circle at top, #fcfbf8 0%, #f8f5f1 55%, #efe7dd 100%);
+    --surface:     rgba(255,255,255,0.92);
+    --surface-border: #ded3c5;
+    --surface-radius: 1.25rem;
+    --surface-shadow: 0 20px 40px rgba(31,27,24,0.08);
+    --text:        #1f1b18;
+    --muted:       #6f6459;
+    --accent:      #2f5d46;
+    --accent-strong: #214332;
+    --border:      #ded3c5;
+    --surface-muted: #f2ece4;
+  }
+
+  body {
+    font-family: var(--font);
+    color: var(--text);
+    background: var(--bg);
+    background-attachment: fixed;
+    line-height: 1.6;
+    -webkit-font-smoothing: antialiased;
+  }
+
+  /* ── Back link ── */
+  .back-link {
+    display: block;
+    padding: 0.75rem 1.5rem;
+    font-size: 0.85rem;
+    color: var(--accent);
+    text-decoration: none;
+    background: var(--surface-muted);
+    border-bottom: 1px solid var(--border);
+  }
+  .back-link:hover { color: var(--accent-strong); text-decoration: underline; }
+
+  /* ── Layout ── */
+  .page-section { max-width: 960px; margin: 0 auto; padding: 0 1.25rem 3rem; }
+
+  /* ── Header ── */
+  .site-header {
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+    padding: 1.5rem 0 1rem;
+    border-bottom: 1px solid var(--border);
+    margin-bottom: 2rem;
+  }
+  .site-header .logo-group { display: flex; flex-direction: column; }
+  .site-header .logo {
+    font-weight: 700;
+    font-size: 1.6rem;
+    color: var(--text);
+    text-decoration: none;
+  }
+  .site-header .tagline {
+    font-size: 0.85rem;
+    color: var(--muted);
+    margin-top: 0.1rem;
+  }
+  .site-header nav { display: flex; gap: 1.25rem; }
+  .site-header nav a {
+    font-size: 0.95rem;
+    color: var(--muted);
+    text-decoration: none;
+    transition: color 0.15s;
+  }
+  .site-header nav a:hover { color: var(--accent); }
+
+  /* ── Card ── */
+  .card {
+    background: var(--surface);
+    border: 1px solid var(--surface-border);
+    border-radius: var(--surface-radius);
+    box-shadow: var(--surface-shadow);
+    padding: 2rem;
+    margin-bottom: 1.5rem;
+  }
+
+  /* ── Eyebrow ── */
+  .eyebrow {
+    display: inline-block;
+    font-size: 0.7rem;
+    font-weight: 700;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--accent);
+    margin-bottom: 0.5rem;
+  }
+
+  /* ── Hero ── */
+  .hero h1 {
+    font-size: 1.75rem;
+    line-height: 1.3;
+    font-weight: 700;
+    margin-bottom: 0.75rem;
+  }
+  .hero .summary {
+    color: var(--muted);
+    font-size: 1rem;
+    max-width: 640px;
+  }
+
+  /* ── Stats ── */
+  .stats-heading {
+    font-size: 1.1rem;
+    font-weight: 700;
+    margin-bottom: 1rem;
+    margin-top: 1rem;
+  }
+  .stats-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+    gap: 1rem;
+    margin-bottom: 2rem;
+  }
+  .stat-card {
+    background: var(--surface);
+    border: 1px solid var(--surface-border);
+    border-radius: var(--surface-radius);
+    box-shadow: var(--surface-shadow);
+    padding: 1.5rem;
+    text-align: center;
+  }
+  .stat-card .stat-value {
+    font-size: 2.25rem;
+    font-weight: 700;
+    color: var(--accent-strong);
+    line-height: 1.1;
+  }
+  .stat-card .stat-label {
+    font-size: 0.85rem;
+    font-weight: 700;
+    margin-top: 0.25rem;
+  }
+  .stat-card .stat-desc {
+    font-size: 0.8rem;
+    color: var(--muted);
+    margin-top: 0.35rem;
+  }
+
+  /* ── Surface cards (catalog, tune) ── */
+  .section-heading {
+    font-size: 1.1rem;
+    font-weight: 700;
+    margin-bottom: 1rem;
+  }
+  .surface-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+    gap: 1rem;
+    margin-bottom: 2rem;
+  }
+  .surface-card {
+    background: var(--surface);
+    border: 1px solid var(--surface-border);
+    border-radius: var(--surface-radius);
+    box-shadow: var(--surface-shadow);
+    padding: 1.5rem;
+  }
+  .surface-card h3 {
+    font-size: 1.1rem;
+    font-weight: 700;
+    margin-bottom: 0.35rem;
+  }
+  .surface-card p {
+    font-size: 0.88rem;
+    color: var(--muted);
+    line-height: 1.5;
+  }
+
+  /* ── Footer ── */
+  .site-footer {
+    text-align: center;
+    padding: 2rem 0 1.5rem;
+    font-size: 0.8rem;
+    color: var(--muted);
+    border-top: 1px solid var(--border);
+    margin-top: 1rem;
+  }
+
+  /* ── Section divider ── */
+  .section-divider {
+    max-width: 960px;
+    margin: 3rem auto;
+    border: none;
+    border-top: 2px dashed var(--border);
+  }
+  .section-divider-label {
+    text-align: center;
+    font-size: 0.75rem;
+    font-weight: 700;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--muted);
+    margin-top: -0.6em;
+    background: #f4efe8;
+    display: table;
+    margin-left: auto;
+    margin-right: auto;
+    padding: 0 1rem;
+    position: relative;
+    top: -0.65rem;
+  }
+
+  /* ── Tune index ── */
+  .page-title { margin-bottom: 1.5rem; }
+  .page-title h1 { font-size: 1.5rem; font-weight: 700; margin-bottom: 0.25rem; }
+  .page-title .lead { font-size: 0.95rem; color: var(--muted); }
+
+  .tune-grid {
+    display: grid;
+    grid-template-columns: 1fr;
+    gap: 1.25rem;
+  }
+
+  .tune-card {
+    background: var(--surface);
+    border: 1px solid var(--surface-border);
+    border-radius: var(--surface-radius);
+    box-shadow: var(--surface-shadow);
+    padding: 1.5rem;
+  }
+  .tune-card .badge {
+    display: inline-block;
+    font-size: 0.65rem;
+    font-weight: 700;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--accent);
+    background: rgba(47,93,70,0.08);
+    padding: 0.15em 0.55em;
+    border-radius: 0.35rem;
+    margin-bottom: 0.5rem;
+  }
+  .tune-card h3 {
+    font-size: 1.15rem;
+    font-weight: 700;
+    margin-bottom: 0.3rem;
+  }
+  .tune-card .tune-summary {
+    font-size: 0.88rem;
+    color: var(--muted);
+    margin-bottom: 0.5rem;
+  }
+  .tune-card .tune-meta {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem 1rem;
+    font-size: 0.78rem;
+    color: var(--muted);
+    margin-bottom: 0.65rem;
+  }
+  .tune-card .tune-meta span { white-space: nowrap; }
+  .tune-card .tune-meta strong { color: var(--text); font-weight: 600; }
+  .tune-card .tune-sets {
+    font-size: 0.8rem;
+    color: var(--muted);
+    margin-bottom: 0.75rem;
+  }
+  .tune-card .tune-sets strong { color: var(--text); font-weight: 600; }
+  .tune-card .tune-aliases {
+    font-size: 0.8rem;
+    color: var(--muted);
+    margin-bottom: 0.75rem;
+    font-style: italic;
+  }
+  .tune-card pre {
+    background: var(--surface-muted);
+    border-radius: 0.6rem;
+    padding: 0.85rem 1rem;
+    font-family: 'SF Mono', 'Fira Code', 'Cascadia Code', 'Menlo', monospace;
+    font-size: 0.78rem;
+    line-height: 1.55;
+    overflow-x: auto;
+    color: var(--text);
+    border: 1px solid var(--border);
+  }
+
+  /* ── Responsive ── */
+  @media (max-width: 640px) {
+    .site-header { flex-direction: column; align-items: flex-start; }
+    .hero h1 { font-size: 1.35rem; }
+    .stats-grid { grid-template-columns: 1fr; }
+    .surface-grid { grid-template-columns: 1fr; }
+    .card { padding: 1.25rem; }
+    .tune-card { padding: 1.25rem; }
+    .tune-card pre { font-size: 0.7rem; padding: 0.65rem; }
+  }
+</style>
+</head>
+<body>
+
+<!-- Back to board -->
+<a class="back-link" href="design-board.html">← Back to Design Board</a>
+
+<!-- ============================================================ -->
+<!-- SECTION 1: HOMEPAGE                                          -->
+<!-- ============================================================ -->
+<div class="page-section">
+
+  <!-- Header -->
+  <header class="site-header">
+    <div class="logo-group">
+      <a class="logo" href="#">SessionBook</a>
+      <span class="tagline">A home for Irish trad chord charts.</span>
+    </div>
+    <nav>
+      <a href="#">Tunes</a>
+      <a href="#">Sets</a>
+    </nav>
+  </header>
+
+  <!-- Hero -->
+  <div class="card hero">
+    <span class="eyebrow">Release 1 public catalog</span>
+    <h1>SessionBook is now a public browseable catalog for Irish&nbsp;trad chord charts.</h1>
+    <p class="summary">The first release opens the door to a curated collection of chord charts for traditional Irish tunes — jigs, reels, hornpipes, and more — organised by set and ready for the session.</p>
+  </div>
+
+  <!-- Stats -->
+  <h2 class="stats-heading">What the imported catalog proves</h2>
+  <div class="stats-grid">
+    <div class="stat-card">
+      <div class="stat-value">42</div>
+      <div class="stat-label">Public tunes</div>
+      <div class="stat-desc">Chord charts imported and verified from the original collection.</div>
+    </div>
+    <div class="stat-card">
+      <div class="stat-value">8</div>
+      <div class="stat-label">Public sets</div>
+      <div class="stat-desc">Curated groupings of tunes played together in session order.</div>
+    </div>
+    <div class="stat-card">
+      <div class="stat-value">3</div>
+      <div class="stat-label">Private gig sheets</div>
+      <div class="stat-desc">Owner-only gig sheets for real-world performance planning.</div>
+    </div>
+  </div>
+
+  <!-- Catalog surfaces -->
+  <h2 class="section-heading">Public catalog surfaces</h2>
+  <div class="surface-grid">
+    <div class="surface-card">
+      <span class="eyebrow">Live</span>
+      <h3>Tunes</h3>
+      <p>Browse the full catalog of chord charts. Filter by key, mode, or meter. Each tune shows its chart, metadata, and which sets it belongs to.</p>
+    </div>
+    <div class="surface-card">
+      <span class="eyebrow">Live</span>
+      <h3>Sets</h3>
+      <p>View curated sets of tunes as they're played in sessions. Each set lists its tunes in order with quick access to individual charts.</p>
+    </div>
+  </div>
+
+  <!-- Footer -->
+  <footer class="site-footer">SessionBook — a home for Irish trad chord charts.</footer>
+
+</div>
+
+<!-- ============================================================ -->
+<!-- DIVIDER                                                      -->
+<!-- ============================================================ -->
+<hr class="section-divider">
+<div class="section-divider-label">Section 2 · Tune Index</div>
+
+<!-- ============================================================ -->
+<!-- SECTION 2: TUNE INDEX                                        -->
+<!-- ============================================================ -->
+<div class="page-section">
+
+  <!-- Header -->
+  <header class="site-header">
+    <div class="logo-group">
+      <a class="logo" href="#">SessionBook</a>
+      <span class="tagline">A home for Irish trad chord charts.</span>
+    </div>
+    <nav>
+      <a href="#">Tunes</a>
+      <a href="#">Sets</a>
+    </nav>
+  </header>
+
+  <!-- Page title -->
+  <div class="page-title">
+    <span class="eyebrow">Live runtime</span>
+    <h1>Tunes</h1>
+    <p class="lead">Browse the full public catalog of Irish trad chord charts.</p>
+  </div>
+
+  <!-- Tune grid -->
+  <div class="tune-grid">
+
+    <!-- 1. Morrison's Jig -->
+    <div class="tune-card">
+      <span class="badge">Jig</span>
+      <h3>Morrison's Jig</h3>
+      <p class="tune-summary">A cornerstone jig in Em Dorian — a must-know for any session.</p>
+      <div class="tune-meta">
+        <span><strong>Key:</strong> Em</span>
+        <span><strong>Mode:</strong> Dorian</span>
+        <span><strong>Meter:</strong> 6/8</span>
+      </div>
+      <p class="tune-aliases">Aliases: Morrison's</p>
+      <p class="tune-sets"><strong>Sets:</strong> Jig Set 1, First Friday December</p>
+<pre>| Em / / / | / / D / | Em / / / | C / D / |
+| Em / / / | / / D / | Em / / / | C / D / |
+| Em / / / | / / D / | C  / / / | D / / / |</pre>
+    </div>
+
+    <!-- 2. The Butterfly -->
+    <div class="tune-card">
+      <span class="badge">Jig</span>
+      <h3>The Butterfly</h3>
+      <p class="tune-summary">A beautiful slip jig in Em Dorian with a flowing, lyrical feel.</p>
+      <div class="tune-meta">
+        <span><strong>Key:</strong> Em</span>
+        <span><strong>Mode:</strong> Dorian</span>
+        <span><strong>Meter:</strong> 6/8</span>
+      </div>
+      <p class="tune-sets"><strong>Sets:</strong> Jig Set 1</p>
+<pre>|  Em  /  /  |  /  /  D  |  Em  /  /  |  D  /  /  |
+|  Am  /  /  |  /  /  Bm  |  Am  /  /  |  /  /  Bm |
+|  Em  /  /  |  / / / | D  /  /  |  / / / |
+|  C   /  /  |  / / / | Bm /  /  |  / / / |</pre>
+    </div>
+
+    <!-- 3. Swallowtail Jig -->
+    <div class="tune-card">
+      <span class="badge">Jig</span>
+      <h3>Swallowtail Jig</h3>
+      <p class="tune-summary">A driving Em jig that sits perfectly alongside Morrison's in a set.</p>
+      <div class="tune-meta">
+        <span><strong>Key:</strong> Em</span>
+        <span><strong>Mode:</strong> Dorian</span>
+        <span><strong>Meter:</strong> 6/8</span>
+      </div>
+      <p class="tune-sets"><strong>Sets:</strong> Jig Set 1</p>
+<pre>| Em /  /  /  |  D  /  /  /  |  Em  /  /  / |  D  /  /  Em |
+| Em /  /  /  |  /  /  /  D  |  Em  /  /  / |  /  D  /  Em  |</pre>
+    </div>
+
+    <!-- 4. Saddle the Pony -->
+    <div class="tune-card">
+      <span class="badge">Jig</span>
+      <h3>Saddle the Pony</h3>
+      <p class="tune-summary">A bright G major jig with a bouncy, uplifting character.</p>
+      <div class="tune-meta">
+        <span><strong>Key:</strong> G</span>
+        <span><strong>Mode:</strong> Major</span>
+        <span><strong>Meter:</strong> 6/8</span>
+      </div>
+      <p class="tune-sets"><strong>Sets:</strong> Jig Set 2</p>
+<pre>| G  / Am / | G / D / | G / Am / | C / D G |
+| Em / / / | /  / D / | Em / / / | C / D G |</pre>
+    </div>
+
+    <!-- 5. The Green Mountain -->
+    <div class="tune-card">
+      <span class="badge">Reel</span>
+      <h3>The Green Mountain</h3>
+      <p class="tune-summary">A solid D major reel — a reliable session staple.</p>
+      <div class="tune-meta">
+        <span><strong>Key:</strong> D</span>
+        <span><strong>Mode:</strong> Major</span>
+        <span><strong>Meter:</strong> 4/4</span>
+      </div>
+      <p class="tune-sets"><strong>Sets:</strong> Reel Set 1</p>
+<pre>| D / / / / | Em / G A | D / / / | Em / A D |
+| D / G / | Em / A  / | D / G / | Em  / A D |</pre>
+    </div>
+
+    <!-- 6. Wind that Shakes the Barley -->
+    <div class="tune-card">
+      <span class="badge">Reel</span>
+      <h3>Wind that Shakes the Barley</h3>
+      <p class="tune-summary">An iconic D major reel — one of the best-known tunes in the tradition.</p>
+      <div class="tune-meta">
+        <span><strong>Key:</strong> D</span>
+        <span><strong>Mode:</strong> Major</span>
+        <span><strong>Meter:</strong> 4/4</span>
+      </div>
+      <p class="tune-sets"><strong>Sets:</strong> Reel Set 1</p>
+<pre>{2x}| D / / / | G / / /  | Bm / / / | A / / / |
+{1x}| D G D / | D G A / | D G D / | G / A / |</pre>
+    </div>
+
+  </div><!-- /tune-grid -->
+
+  <!-- Footer -->
+  <footer class="site-footer">SessionBook — a home for Irish trad chord charts.</footer>
+
+</div>
+
+</body>
+</html>

--- a/design-option-b.html
+++ b/design-option-b.html
@@ -1,0 +1,573 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>SessionBook — Option B: Clean Modern</title>
+<style>
+  *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+  :root {
+    --font: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+    --mono: 'SF Mono', 'Fira Code', 'Fira Mono', 'Roboto Mono', monospace;
+    --bg: #f9fafb;
+    --surface: #ffffff;
+    --border: #e5e7eb;
+    --shadow: 0 1px 3px rgba(0,0,0,0.05);
+    --radius: 0.75rem;
+    --radius-sm: 0.5rem;
+    --text: #111827;
+    --muted: #6b7280;
+    --green-bg: #ecfdf5;
+    --green: #059669;
+    --blue-bg: #eff6ff;
+    --blue: #2563eb;
+    --chip-bg: #f3f4f6;
+    --chip-text: #374151;
+  }
+
+  html { scroll-behavior: smooth; }
+
+  body {
+    font-family: var(--font);
+    background: var(--bg);
+    color: var(--text);
+    line-height: 1.6;
+    -webkit-font-smoothing: antialiased;
+  }
+
+  /* Back link */
+  .back-strip {
+    background: var(--surface);
+    border-bottom: 1px solid var(--border);
+    padding: 0.5rem 1.5rem;
+    font-size: 0.8125rem;
+  }
+  .back-strip a {
+    color: var(--muted);
+    text-decoration: none;
+    transition: color 0.15s;
+  }
+  .back-strip a:hover { color: var(--text); }
+
+  /* Section divider */
+  .section-divider {
+    max-width: 56rem;
+    margin: 3rem auto 0;
+    padding: 0 1.5rem;
+  }
+  .section-divider hr {
+    border: none;
+    border-top: 2px dashed var(--border);
+  }
+  .section-divider .label {
+    display: inline-block;
+    background: var(--blue-bg);
+    color: var(--blue);
+    font-size: 0.6875rem;
+    font-weight: 700;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    padding: 0.25rem 0.75rem;
+    border-radius: 999px;
+    margin-top: 0.75rem;
+  }
+
+  /* ─── HEADER ─── */
+  .site-header {
+    background: var(--surface);
+    border-bottom: 1px solid var(--border);
+    box-shadow: var(--shadow);
+    position: sticky;
+    top: 0;
+    z-index: 100;
+  }
+  .site-header .inner {
+    max-width: 56rem;
+    margin: 0 auto;
+    padding: 0 1.5rem;
+    height: 3.5rem;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+  }
+  .logo {
+    font-size: 1.125rem;
+    font-weight: 800;
+    color: var(--text);
+    text-decoration: none;
+    letter-spacing: -0.02em;
+  }
+  .nav-links { display: flex; gap: 1.5rem; }
+  .nav-links a {
+    font-size: 0.875rem;
+    font-weight: 600;
+    color: var(--muted);
+    text-decoration: none;
+    transition: color 0.15s;
+  }
+  .nav-links a:hover { color: var(--text); }
+
+  /* ─── HERO ─── */
+  .hero {
+    max-width: 56rem;
+    margin: 0 auto;
+    padding: 4rem 1.5rem 2.5rem;
+    text-align: center;
+  }
+  .hero h1 {
+    font-size: 2.25rem;
+    font-weight: 800;
+    letter-spacing: -0.03em;
+    line-height: 1.2;
+    color: var(--text);
+  }
+  .hero p {
+    margin-top: 1rem;
+    font-size: 1.0625rem;
+    color: var(--muted);
+    max-width: 32rem;
+    margin-left: auto;
+    margin-right: auto;
+  }
+  .hero-actions {
+    margin-top: 2rem;
+    display: flex;
+    gap: 0.75rem;
+    justify-content: center;
+    flex-wrap: wrap;
+  }
+  .btn {
+    display: inline-flex;
+    align-items: center;
+    padding: 0.625rem 1.5rem;
+    border-radius: 999px;
+    font-size: 0.875rem;
+    font-weight: 600;
+    text-decoration: none;
+    transition: all 0.15s;
+    cursor: pointer;
+    border: 2px solid transparent;
+  }
+  .btn-primary {
+    background: var(--green);
+    color: #fff;
+    border-color: var(--green);
+  }
+  .btn-primary:hover { background: #047857; border-color: #047857; }
+  .btn-outline {
+    background: transparent;
+    color: var(--text);
+    border-color: var(--border);
+  }
+  .btn-outline:hover { border-color: var(--muted); }
+
+  /* ─── STATS ─── */
+  .stats {
+    max-width: 56rem;
+    margin: 0 auto;
+    padding: 0 1.5rem 2.5rem;
+  }
+  .stats-grid {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 1rem;
+  }
+  .stat-card {
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    box-shadow: var(--shadow);
+    padding: 1.5rem;
+    text-align: center;
+  }
+  .stat-card .number {
+    font-size: 2rem;
+    font-weight: 800;
+    letter-spacing: -0.03em;
+    color: var(--text);
+  }
+  .stat-card .label {
+    font-size: 0.8125rem;
+    font-weight: 600;
+    color: var(--muted);
+    margin-top: 0.125rem;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+  }
+  .stat-card .desc {
+    font-size: 0.8125rem;
+    color: var(--muted);
+    margin-top: 0.5rem;
+  }
+
+  /* ─── LINK SECTIONS ─── */
+  .home-sections {
+    max-width: 56rem;
+    margin: 0 auto;
+    padding: 0 1.5rem 3rem;
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 1rem;
+  }
+  .link-card {
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    box-shadow: var(--shadow);
+    padding: 1.5rem;
+  }
+  .link-card h3 {
+    font-size: 1rem;
+    font-weight: 700;
+    margin-bottom: 0.75rem;
+  }
+  .link-card ul {
+    list-style: none;
+    display: flex;
+    flex-direction: column;
+    gap: 0.375rem;
+  }
+  .link-card ul a {
+    font-size: 0.875rem;
+    color: var(--blue);
+    text-decoration: none;
+    font-weight: 500;
+  }
+  .link-card ul a:hover { text-decoration: underline; }
+
+  /* ─── FOOTER ─── */
+  .site-footer {
+    max-width: 56rem;
+    margin: 0 auto;
+    padding: 1.5rem;
+    text-align: center;
+    font-size: 0.75rem;
+    color: var(--muted);
+    border-top: 1px solid var(--border);
+  }
+
+  /* ─── TUNE INDEX ─── */
+  .tune-index {
+    max-width: 56rem;
+    margin: 0 auto;
+    padding: 2.5rem 1.5rem 3rem;
+  }
+  .tune-index > h2 {
+    font-size: 1.5rem;
+    font-weight: 800;
+    letter-spacing: -0.02em;
+    margin-bottom: 0.25rem;
+  }
+  .tune-index > p {
+    color: var(--muted);
+    font-size: 0.9375rem;
+    margin-bottom: 1.5rem;
+  }
+  .tune-grid {
+    display: grid;
+    grid-template-columns: repeat(2, 1fr);
+    gap: 1rem;
+  }
+
+  /* ─── TUNE CARD ─── */
+  .tune-card {
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    box-shadow: var(--shadow);
+    padding: 1.25rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+  }
+  .tune-card-header {
+    display: flex;
+    align-items: flex-start;
+    gap: 0.5rem;
+    flex-wrap: wrap;
+  }
+  .tune-card-header h3 {
+    font-size: 1rem;
+    font-weight: 700;
+    letter-spacing: -0.01em;
+    flex-shrink: 0;
+  }
+  .badges { display: flex; gap: 0.375rem; flex-wrap: wrap; }
+  .badge {
+    display: inline-flex;
+    align-items: center;
+    padding: 0.125rem 0.5rem;
+    border-radius: 999px;
+    font-size: 0.6875rem;
+    font-weight: 600;
+    white-space: nowrap;
+  }
+  .badge-green { background: var(--green-bg); color: var(--green); }
+  .badge-blue  { background: var(--blue-bg);  color: var(--blue);  }
+
+  .tune-summary {
+    font-size: 0.8125rem;
+    color: var(--muted);
+    line-height: 1.5;
+  }
+
+  .chips { display: flex; gap: 0.375rem; flex-wrap: wrap; }
+  .chip {
+    display: inline-flex;
+    align-items: center;
+    padding: 0.1875rem 0.5rem;
+    background: var(--chip-bg);
+    color: var(--chip-text);
+    border-radius: var(--radius-sm);
+    font-size: 0.6875rem;
+    font-weight: 500;
+  }
+
+  .chart-block {
+    background: var(--bg);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-sm);
+    padding: 0.75rem 1rem;
+    overflow-x: auto;
+  }
+  .chart-block pre {
+    font-family: var(--mono);
+    font-size: 0.75rem;
+    line-height: 1.7;
+    margin: 0;
+    white-space: pre;
+    color: var(--text);
+  }
+
+  /* ─── RESPONSIVE ─── */
+  @media (max-width: 640px) {
+    .hero h1 { font-size: 1.625rem; }
+    .stats-grid { grid-template-columns: 1fr; }
+    .home-sections { grid-template-columns: 1fr; }
+    .tune-grid { grid-template-columns: 1fr; }
+    .tune-card-header { flex-direction: column; }
+  }
+</style>
+</head>
+<body>
+
+<!-- Back to Design Board -->
+<div class="back-strip">
+  <a href="design-board.html">← Back to Design Board</a>
+</div>
+
+<!-- ════════════════════════════════════════════
+     SECTION 1: HOMEPAGE
+     ════════════════════════════════════════════ -->
+
+<header class="site-header">
+  <div class="inner">
+    <a class="logo" href="#">SessionBook</a>
+    <nav class="nav-links">
+      <a href="#tune-index">Tunes</a>
+      <a href="#">Sets</a>
+    </nav>
+  </div>
+</header>
+
+<section class="hero">
+  <h1>A public catalog for Irish trad chord charts</h1>
+  <p>Open-source chord charts for Irish traditional tunes — built for guitarists, bouzouki players, and accompanists at the session.</p>
+  <div class="hero-actions">
+    <a href="#tune-index" class="btn btn-primary">Browse Tunes</a>
+    <a href="#" class="btn btn-outline">Browse Sets</a>
+  </div>
+</section>
+
+<section class="stats">
+  <div class="stats-grid">
+    <div class="stat-card">
+      <div class="number">6</div>
+      <div class="label">Tunes</div>
+      <div class="desc">Jigs, reels, and more with chord charts</div>
+    </div>
+    <div class="stat-card">
+      <div class="number">3</div>
+      <div class="label">Sets</div>
+      <div class="desc">Curated groups of tunes for the session</div>
+    </div>
+    <div class="stat-card">
+      <div class="number">2</div>
+      <div class="label">Tune Types</div>
+      <div class="desc">Jigs and reels — more to come</div>
+    </div>
+  </div>
+</section>
+
+<section class="home-sections">
+  <div class="link-card">
+    <h3>Tunes</h3>
+    <ul>
+      <li><a href="#">Morrison's Jig</a></li>
+      <li><a href="#">The Butterfly</a></li>
+      <li><a href="#">Swallowtail Jig</a></li>
+      <li><a href="#">Saddle the Pony</a></li>
+      <li><a href="#">The Green Mountain</a></li>
+      <li><a href="#">Wind that Shakes the Barley</a></li>
+    </ul>
+  </div>
+  <div class="link-card">
+    <h3>Sets</h3>
+    <ul>
+      <li><a href="#">Jig Set 1</a></li>
+      <li><a href="#">Jig Set 2</a></li>
+      <li><a href="#">Reel Set 1</a></li>
+    </ul>
+  </div>
+</section>
+
+<footer class="site-footer">SessionBook — Open-source Irish trad chord charts</footer>
+
+<!-- Section Divider -->
+<div class="section-divider">
+  <hr>
+  <span class="label">Section 2 — Tune Index</span>
+</div>
+
+<!-- ════════════════════════════════════════════
+     SECTION 2: TUNE INDEX
+     ════════════════════════════════════════════ -->
+
+<section class="tune-index" id="tune-index">
+  <h2>Tunes</h2>
+  <p>6 tunes with chord charts for Irish trad sessions.</p>
+
+  <div class="tune-grid">
+
+    <!-- 1. Morrison's Jig -->
+    <article class="tune-card">
+      <div class="tune-card-header">
+        <h3>Morrison's Jig</h3>
+        <div class="badges">
+          <span class="badge badge-green">Jig</span>
+          <span class="badge badge-blue">Em</span>
+        </div>
+      </div>
+      <div class="tune-summary">A cornerstone session jig in E minor. Sets: Jig Set 1, First Friday December.</div>
+      <div class="chips">
+        <span class="chip">Dorian</span>
+        <span class="chip">6/8</span>
+        <span class="chip">aka Morrison's</span>
+      </div>
+      <div class="chart-block">
+<pre>| Em / / / | / / D / | Em / / / | C / D / |
+| Em / / / | / / D / | Em / / / | C / D / |
+| Em / / / | / / D / | C  / / / | D / / / |</pre>
+      </div>
+    </article>
+
+    <!-- 2. The Butterfly -->
+    <article class="tune-card">
+      <div class="tune-card-header">
+        <h3>The Butterfly</h3>
+        <div class="badges">
+          <span class="badge badge-green">Jig</span>
+          <span class="badge badge-blue">Em</span>
+        </div>
+      </div>
+      <div class="tune-summary">A beautiful slip jig–style melody in E minor. Sets: Jig Set 1.</div>
+      <div class="chips">
+        <span class="chip">Dorian</span>
+        <span class="chip">6/8</span>
+      </div>
+      <div class="chart-block">
+<pre>|  Em  /  /  |  /  /  D  |  Em  /  /  |  D  /  /  |
+|  Am  /  /  |  /  /  Bm  |  Am  /  /  |  /  /  Bm |
+|  Em  /  /  |  / / / | D  /  /  |  / / / |
+|  C   /  /  |  / / / | Bm /  /  |  / / / |</pre>
+      </div>
+    </article>
+
+    <!-- 3. Swallowtail Jig -->
+    <article class="tune-card">
+      <div class="tune-card-header">
+        <h3>Swallowtail Jig</h3>
+        <div class="badges">
+          <span class="badge badge-green">Jig</span>
+          <span class="badge badge-blue">Em</span>
+        </div>
+      </div>
+      <div class="tune-summary">A driving session jig in E minor. Sets: Jig Set 1.</div>
+      <div class="chips">
+        <span class="chip">Dorian</span>
+        <span class="chip">6/8</span>
+      </div>
+      <div class="chart-block">
+<pre>| Em /  /  /  |  D  /  /  /  |  Em  /  /  / |  D  /  /  Em |
+| Em /  /  /  |  /  /  /  D  |  Em  /  /  / |  /  D  /  Em  |</pre>
+      </div>
+    </article>
+
+    <!-- 4. Saddle the Pony -->
+    <article class="tune-card">
+      <div class="tune-card-header">
+        <h3>Saddle the Pony</h3>
+        <div class="badges">
+          <span class="badge badge-green">Jig</span>
+          <span class="badge badge-blue">G</span>
+        </div>
+      </div>
+      <div class="tune-summary">A bright jig in G major. Sets: Jig Set 2.</div>
+      <div class="chips">
+        <span class="chip">Major</span>
+        <span class="chip">6/8</span>
+      </div>
+      <div class="chart-block">
+<pre>| G  / Am / | G / D / | G / Am / | C / D G |
+| Em / / / | /  / D / | Em / / / | C / D G |</pre>
+      </div>
+    </article>
+
+    <!-- 5. The Green Mountain -->
+    <article class="tune-card">
+      <div class="tune-card-header">
+        <h3>The Green Mountain</h3>
+        <div class="badges">
+          <span class="badge badge-green">Reel</span>
+          <span class="badge badge-blue">D</span>
+        </div>
+      </div>
+      <div class="tune-summary">A popular session reel in D major. Sets: Reel Set 1.</div>
+      <div class="chips">
+        <span class="chip">Major</span>
+        <span class="chip">4/4</span>
+      </div>
+      <div class="chart-block">
+<pre>| D / / / / | Em / G A | D / / / | Em / A D |
+| D / G / | Em / A  / | D / G / | Em  / A D |</pre>
+      </div>
+    </article>
+
+    <!-- 6. Wind that Shakes the Barley -->
+    <article class="tune-card">
+      <div class="tune-card-header">
+        <h3>Wind that Shakes the Barley</h3>
+        <div class="badges">
+          <span class="badge badge-green">Reel</span>
+          <span class="badge badge-blue">D</span>
+        </div>
+      </div>
+      <div class="tune-summary">A classic reel in D major. Sets: Reel Set 1.</div>
+      <div class="chips">
+        <span class="chip">Major</span>
+        <span class="chip">4/4</span>
+      </div>
+      <div class="chart-block">
+<pre>{2x}| D / / / | G / / /  | Bm / / / | A / / / |
+{1x}| D G D / | D G A / | D G D / | G / A / |</pre>
+      </div>
+    </article>
+
+  </div><!-- /tune-grid -->
+</section>
+
+<footer class="site-footer">SessionBook — Open-source Irish trad chord charts</footer>
+
+</body>
+</html>

--- a/design-option-c.html
+++ b/design-option-c.html
@@ -1,0 +1,501 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>SessionBook — Option C: Dark &amp; Warm</title>
+<style>
+  *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+  :root {
+    --bg: #1c1917;
+    --surface: #292524;
+    --border: #44403c;
+    --text: #e7e5e4;
+    --heading: #fafaf9;
+    --muted: #a8a29e;
+    --accent: #a3e635;
+    --chart-bg: #292524;
+    --chart-text: #d6d3d1;
+    --radius: 1rem;
+    --radius-sm: .75rem;
+    --font: Georgia, 'Times New Roman', serif;
+    --mono: 'SF Mono', 'Cascadia Code', 'Fira Code', 'Consolas', monospace;
+  }
+
+  html { scroll-behavior: smooth; }
+
+  body {
+    font-family: var(--font);
+    background: var(--bg);
+    color: var(--text);
+    line-height: 1.6;
+    -webkit-font-smoothing: antialiased;
+  }
+
+  a { color: inherit; text-decoration: none; }
+
+  /* ── Back link ── */
+  .back-link {
+    display: inline-block;
+    padding: 1rem 1.5rem;
+    color: var(--muted);
+    font-size: .875rem;
+    transition: color .2s;
+  }
+  .back-link:hover { color: var(--accent); }
+
+  /* ── Design label ── */
+  .design-label {
+    text-align: center;
+    padding: 1.25rem 1rem .25rem;
+    color: var(--muted);
+    font-size: .8rem;
+    letter-spacing: .12em;
+    text-transform: uppercase;
+  }
+
+  /* ── Section divider ── */
+  .section-divider {
+    max-width: 72rem;
+    margin: 4rem auto 2rem;
+    padding: 0 1.5rem;
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+    color: var(--muted);
+    font-size: .75rem;
+    letter-spacing: .15em;
+    text-transform: uppercase;
+  }
+  .section-divider::before,
+  .section-divider::after {
+    content: '';
+    flex: 1;
+    height: 1px;
+    background: var(--border);
+  }
+
+  /* ══════════════════════════════════════
+     SECTION 1 — HOMEPAGE
+     ══════════════════════════════════════ */
+
+  /* ── Header ── */
+  .site-header {
+    max-width: 72rem;
+    margin: 0 auto;
+    padding: 1.25rem 1.5rem;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+  }
+  .logo {
+    font-size: 1.35rem;
+    font-weight: 700;
+    color: var(--heading);
+    letter-spacing: -.01em;
+  }
+  .logo span { color: var(--accent); }
+  .nav-links { display: flex; gap: 1.75rem; }
+  .nav-links a {
+    font-size: .9rem;
+    color: var(--accent);
+    transition: opacity .2s;
+  }
+  .nav-links a:hover { opacity: .75; }
+
+  /* ── Hero ── */
+  .hero {
+    max-width: 72rem;
+    margin: 2rem auto 0;
+    padding: 0 1.5rem;
+  }
+  .hero-card {
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    padding: 3rem 2.5rem;
+    text-align: center;
+  }
+  .hero-card .badge {
+    display: inline-block;
+    background: rgba(163,230,53,.12);
+    color: var(--accent);
+    font-size: .75rem;
+    font-weight: 700;
+    letter-spacing: .06em;
+    text-transform: uppercase;
+    padding: .35rem .9rem;
+    border-radius: 9999px;
+    margin-bottom: 1.25rem;
+  }
+  .hero-card h1 {
+    font-size: clamp(1.75rem, 4vw, 2.75rem);
+    color: var(--heading);
+    line-height: 1.25;
+    margin-bottom: 1rem;
+    font-weight: 700;
+  }
+  .hero-card p {
+    max-width: 38rem;
+    margin: 0 auto;
+    color: var(--muted);
+    font-size: 1.05rem;
+    line-height: 1.7;
+  }
+
+  /* ── Stats ── */
+  .stats {
+    max-width: 72rem;
+    margin: 2rem auto 0;
+    padding: 0 1.5rem;
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(14rem, 1fr));
+    gap: 1rem;
+  }
+  .stat-card {
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    padding: 1.75rem 1.5rem;
+    text-align: center;
+  }
+  .stat-card .number {
+    font-size: 2.25rem;
+    font-weight: 700;
+    color: var(--heading);
+    line-height: 1.1;
+  }
+  .stat-card .label {
+    margin-top: .35rem;
+    font-size: .85rem;
+    color: var(--accent);
+    text-transform: uppercase;
+    letter-spacing: .08em;
+    font-weight: 600;
+  }
+
+  /* ── Feature cards ── */
+  .features {
+    max-width: 72rem;
+    margin: 2rem auto 0;
+    padding: 0 1.5rem;
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(20rem, 1fr));
+    gap: 1rem;
+  }
+  .feature-card {
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    padding: 2rem 1.75rem;
+  }
+  .feature-card h3 {
+    color: var(--heading);
+    font-size: 1.15rem;
+    margin-bottom: .5rem;
+  }
+  .feature-card p {
+    color: var(--muted);
+    font-size: .95rem;
+    line-height: 1.65;
+  }
+  .feature-card .cta {
+    display: inline-block;
+    margin-top: 1rem;
+    color: var(--accent);
+    font-size: .9rem;
+    font-weight: 600;
+  }
+  .feature-card .cta:hover { text-decoration: underline; }
+
+  /* ── Footer ── */
+  .site-footer {
+    max-width: 72rem;
+    margin: 3rem auto 0;
+    padding: 2rem 1.5rem;
+    border-top: 1px solid var(--border);
+    text-align: center;
+    color: var(--muted);
+    font-size: .8rem;
+  }
+
+  /* ══════════════════════════════════════
+     SECTION 2 — TUNE INDEX
+     ══════════════════════════════════════ */
+
+  .tune-index {
+    max-width: 72rem;
+    margin: 0 auto;
+    padding: 0 1.5rem 4rem;
+  }
+  .tune-index-header {
+    margin-bottom: 1.5rem;
+  }
+  .tune-index-header h2 {
+    color: var(--heading);
+    font-size: 1.5rem;
+    margin-bottom: .25rem;
+  }
+  .tune-index-header p {
+    color: var(--muted);
+    font-size: .95rem;
+  }
+
+  .tune-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(22rem, 1fr));
+    gap: 1.25rem;
+  }
+
+  .tune-card {
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    padding: 1.5rem;
+    display: flex;
+    flex-direction: column;
+    gap: .75rem;
+  }
+  .tune-card .type-badge {
+    align-self: flex-start;
+    background: rgba(163,230,53,.12);
+    color: var(--accent);
+    font-size: .65rem;
+    font-weight: 700;
+    letter-spacing: .1em;
+    text-transform: uppercase;
+    padding: .25rem .7rem;
+    border-radius: 9999px;
+  }
+  .tune-card h3 {
+    color: var(--heading);
+    font-size: 1.1rem;
+    line-height: 1.3;
+  }
+  .tune-card .meta {
+    color: var(--muted);
+    font-size: .82rem;
+    line-height: 1.5;
+  }
+  .tune-card .meta strong {
+    color: var(--text);
+    font-weight: 600;
+  }
+
+  /* Chart block */
+  .chart-block {
+    background: var(--chart-bg);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-sm);
+    padding: 1rem 1.125rem;
+    font-family: var(--mono);
+    font-size: .78rem;
+    line-height: 1.7;
+    color: var(--chart-text);
+    overflow-x: auto;
+    white-space: pre;
+  }
+
+  /* Tag pills */
+  .tags { display: flex; flex-wrap: wrap; gap: .4rem; }
+  .tag {
+    background: var(--surface);
+    border: 1px solid var(--border);
+    color: var(--muted);
+    font-size: .7rem;
+    padding: .2rem .6rem;
+    border-radius: 9999px;
+    white-space: nowrap;
+  }
+
+  /* ── Responsive ── */
+  @media (max-width: 640px) {
+    .site-header { flex-direction: column; gap: .75rem; }
+    .nav-links { gap: 1.25rem; }
+    .hero-card { padding: 2rem 1.25rem; }
+    .tune-grid { grid-template-columns: 1fr; }
+    .features { grid-template-columns: 1fr; }
+  }
+</style>
+</head>
+<body>
+
+<!-- Back link -->
+<a href="design-board.html" class="back-link">← Back to Design Board</a>
+
+<p class="design-label">Option C — Dark &amp; Warm</p>
+
+<!-- ════════════════════════════════════════════
+     SECTION 1: HOMEPAGE
+     ════════════════════════════════════════════ -->
+
+<header class="site-header">
+  <div class="logo">Session<span>Book</span></div>
+  <nav class="nav-links">
+    <a href="#">Tunes</a>
+    <a href="#">Sets</a>
+    <a href="#">Sessions</a>
+    <a href="#">About</a>
+  </nav>
+</header>
+
+<section class="hero">
+  <div class="hero-card">
+    <span class="badge">Release 1 · Public Catalog</span>
+    <h1>Irish Trad Chord Charts,<br>Ready for the Session</h1>
+    <p>A curated catalog of chord charts for Irish traditional tunes — jigs, reels, hornpipes, and more. Organized into sets, tagged by key and mode, and built for musicians who back tunes on guitar, bouzouki, or keys.</p>
+  </div>
+</section>
+
+<div class="stats">
+  <div class="stat-card">
+    <div class="number">42</div>
+    <div class="label">Tunes</div>
+  </div>
+  <div class="stat-card">
+    <div class="number">8</div>
+    <div class="label">Sets</div>
+  </div>
+  <div class="stat-card">
+    <div class="number">5</div>
+    <div class="label">Sessions</div>
+  </div>
+</div>
+
+<div class="features">
+  <div class="feature-card">
+    <h3>Tunes</h3>
+    <p>Browse the full catalog of chord charts. Each tune includes key, mode, time signature, and the sets it belongs to.</p>
+    <a href="#tune-index" class="cta">Browse tunes →</a>
+  </div>
+  <div class="feature-card">
+    <h3>Sets</h3>
+    <p>Tunes grouped the way they're played in sessions — two or three tunes back to back, in the order you'll need them.</p>
+    <a href="#" class="cta">View sets →</a>
+  </div>
+</div>
+
+<footer class="site-footer">
+  SessionBook · Irish Trad Chord Charts
+</footer>
+
+<!-- ════════════════════════════════════════════
+     SECTION 2: TUNE INDEX
+     ════════════════════════════════════════════ -->
+
+<div class="section-divider" id="tune-index">Section 2 — Tune Index</div>
+
+<section class="tune-index">
+  <div class="tune-index-header">
+    <h2>Tunes</h2>
+    <p>6 tunes in the catalog</p>
+  </div>
+
+  <div class="tune-grid">
+
+    <!-- 1 — Morrison's Jig -->
+    <article class="tune-card">
+      <span class="type-badge">Jig</span>
+      <h3>Morrison's Jig</h3>
+      <div class="meta">
+        <strong>Sets:</strong> Jig Set 1, First Friday December<br>
+        <strong>Aliases:</strong> Morrison's
+      </div>
+      <div class="chart-block">| Em / / / | / / D / | Em / / / | C / D / |
+| Em / / / | / / D / | Em / / / | C / D / |
+| Em / / / | / / D / | C  / / / | D / / / |</div>
+      <div class="tags">
+        <span class="tag">Em</span>
+        <span class="tag">Dorian</span>
+        <span class="tag">6/8</span>
+      </div>
+    </article>
+
+    <!-- 2 — The Butterfly -->
+    <article class="tune-card">
+      <span class="type-badge">Jig</span>
+      <h3>The Butterfly</h3>
+      <div class="meta">
+        <strong>Sets:</strong> Jig Set 1
+      </div>
+      <div class="chart-block">|  Em  /  /  |  /  /  D  |  Em  /  /  |  D  /  /  |
+|  Am  /  /  |  /  /  Bm  |  Am  /  /  |  /  /  Bm |
+|  Em  /  /  |  / / / | D  /  /  |  / / / |
+|  C   /  /  |  / / / | Bm /  /  |  / / / |</div>
+      <div class="tags">
+        <span class="tag">Em</span>
+        <span class="tag">Dorian</span>
+        <span class="tag">6/8</span>
+      </div>
+    </article>
+
+    <!-- 3 — Swallowtail Jig -->
+    <article class="tune-card">
+      <span class="type-badge">Jig</span>
+      <h3>Swallowtail Jig</h3>
+      <div class="meta">
+        <strong>Sets:</strong> Jig Set 1
+      </div>
+      <div class="chart-block">| Em /  /  /  |  D  /  /  /  |  Em  /  /  / |  D  /  /  Em |
+| Em /  /  /  |  /  /  /  D  |  Em  /  /  / |  /  D  /  Em  |</div>
+      <div class="tags">
+        <span class="tag">Em</span>
+        <span class="tag">Dorian</span>
+        <span class="tag">6/8</span>
+      </div>
+    </article>
+
+    <!-- 4 — Saddle the Pony -->
+    <article class="tune-card">
+      <span class="type-badge">Jig</span>
+      <h3>Saddle the Pony</h3>
+      <div class="meta">
+        <strong>Sets:</strong> Jig Set 2
+      </div>
+      <div class="chart-block">| G  / Am / | G / D / | G / Am / | C / D G |
+| Em / / / | /  / D / | Em / / / | C / D G |</div>
+      <div class="tags">
+        <span class="tag">G</span>
+        <span class="tag">Major</span>
+        <span class="tag">6/8</span>
+      </div>
+    </article>
+
+    <!-- 5 — The Green Mountain -->
+    <article class="tune-card">
+      <span class="type-badge">Reel</span>
+      <h3>The Green Mountain</h3>
+      <div class="meta">
+        <strong>Sets:</strong> Reel Set 1
+      </div>
+      <div class="chart-block">| D / / / / | Em / G A | D / / / | Em / A D |
+| D / G / | Em / A  / | D / G / | Em  / A D |</div>
+      <div class="tags">
+        <span class="tag">D</span>
+        <span class="tag">Major</span>
+        <span class="tag">4/4</span>
+      </div>
+    </article>
+
+    <!-- 6 — Wind that Shakes the Barley -->
+    <article class="tune-card">
+      <span class="type-badge">Reel</span>
+      <h3>Wind that Shakes the Barley</h3>
+      <div class="meta">
+        <strong>Sets:</strong> Reel Set 1
+      </div>
+      <div class="chart-block"><span style="color:var(--accent);font-size:.7rem;opacity:.7">{2x}</span>| D / / / | G / / /  | Bm / / / | A / / / |
+<span style="color:var(--accent);font-size:.7rem;opacity:.7">{1x}</span>| D G D / | D G A / | D G D / | G / A / |</div>
+      <div class="tags">
+        <span class="tag">D</span>
+        <span class="tag">Major</span>
+        <span class="tag">4/4</span>
+      </div>
+    </article>
+
+  </div>
+</section>
+
+</body>
+</html>

--- a/design-option-d.html
+++ b/design-option-d.html
@@ -1,0 +1,490 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>SessionBook — Option D: Acoustic / Editorial</title>
+<style>
+  *, *::before, *::after { margin: 0; padding: 0; box-sizing: border-box; }
+
+  :root {
+    --font-serif: 'Iowan Old Style', Palatino, 'Palatino Linotype', 'Book Antiqua', serif;
+    --font-mono: 'SF Mono', 'Cascadia Code', 'Fira Mono', 'Consolas', monospace;
+    --bg: #fdfcfa;
+    --surface: #ffffff;
+    --text: #292524;
+    --muted: #78716c;
+    --accent: #b45309;
+    --gold: #d4a854;
+    --chart-bg: #faf5ee;
+    --chart-text: #44403c;
+    --divider: #e7e5e4;
+  }
+
+  body {
+    font-family: var(--font-serif);
+    background: var(--bg);
+    color: var(--text);
+    line-height: 1.7;
+    -webkit-font-smoothing: antialiased;
+  }
+
+  .back-link {
+    display: inline-block;
+    padding: 1rem 1.5rem;
+    font-size: 0.85rem;
+    color: var(--muted);
+    text-decoration: none;
+    letter-spacing: 0.02em;
+  }
+  .back-link:hover { color: var(--accent); }
+
+  /* ── Section divider ── */
+  .section-divider {
+    max-width: 720px;
+    margin: 0 auto;
+    padding: 3rem 1.5rem 1rem;
+    border-top: 1px solid var(--divider);
+  }
+  .section-divider span {
+    display: inline-block;
+    font-size: 0.7rem;
+    letter-spacing: 0.15em;
+    text-transform: uppercase;
+    color: var(--accent);
+    background: var(--bg);
+    padding-right: 0.75rem;
+    position: relative;
+    top: -0.35rem;
+  }
+
+  /* ═══════════════════════════════════════
+     SECTION 1: HOMEPAGE
+     ═══════════════════════════════════════ */
+
+  .site-header {
+    max-width: 720px;
+    margin: 0 auto;
+    padding: 2.5rem 1.5rem 2rem;
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    flex-wrap: wrap;
+    gap: 1rem;
+    border-bottom: 1px solid var(--divider);
+  }
+  .site-header .logo-group {
+    display: flex;
+    align-items: baseline;
+    gap: 1.25rem;
+    flex-wrap: wrap;
+  }
+  .site-header h1 {
+    font-size: 1.65rem;
+    font-weight: 400;
+    letter-spacing: -0.01em;
+    color: var(--text);
+  }
+  .site-header .tagline {
+    font-style: italic;
+    font-size: 0.9rem;
+    color: var(--muted);
+  }
+  .site-header nav {
+    display: flex;
+    gap: 1.5rem;
+  }
+  .site-header nav a {
+    font-size: 0.85rem;
+    color: var(--accent);
+    text-decoration: none;
+    letter-spacing: 0.02em;
+  }
+  .site-header nav a:hover {
+    text-decoration: underline;
+    text-underline-offset: 3px;
+  }
+
+  /* Hero */
+  .hero {
+    max-width: 720px;
+    margin: 0 auto;
+    padding: 4rem 1.5rem 3rem;
+  }
+  .hero h2 {
+    font-size: 2.4rem;
+    font-weight: 400;
+    font-style: italic;
+    line-height: 1.3;
+    color: var(--text);
+    max-width: 560px;
+  }
+  .hero .amber-rule {
+    width: 80px;
+    height: 2px;
+    background: var(--accent);
+    margin: 1.75rem 0;
+  }
+  .hero p {
+    font-size: 1.05rem;
+    color: var(--muted);
+    max-width: 520px;
+    line-height: 1.8;
+  }
+
+  /* Stats — pull-quote style */
+  .stats-section {
+    max-width: 720px;
+    margin: 0 auto;
+    padding: 1rem 1.5rem 3rem;
+    border-top: 1px solid var(--divider);
+  }
+  .stats-row {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+    gap: 2.5rem;
+    padding-top: 2rem;
+  }
+  .stat {
+    border-left: 2px solid var(--gold);
+    padding-left: 1.25rem;
+  }
+  .stat .number {
+    font-size: 2.2rem;
+    font-weight: 400;
+    color: var(--text);
+    line-height: 1.2;
+    letter-spacing: -0.02em;
+  }
+  .stat .label {
+    font-size: 0.85rem;
+    color: var(--muted);
+    font-style: italic;
+    margin-top: 0.25rem;
+  }
+
+  /* Editorial nav links */
+  .editorial-nav {
+    max-width: 720px;
+    margin: 0 auto;
+    padding: 0 1.5rem 3.5rem;
+  }
+  .editorial-nav ul {
+    list-style: none;
+    border-top: 1px solid var(--divider);
+  }
+  .editorial-nav li {
+    border-bottom: 1px solid var(--divider);
+  }
+  .editorial-nav a {
+    display: flex;
+    justify-content: space-between;
+    align-items: baseline;
+    padding: 1rem 0;
+    text-decoration: none;
+    color: var(--text);
+    transition: color 0.15s;
+  }
+  .editorial-nav a:hover { color: var(--accent); }
+  .editorial-nav .nav-title {
+    font-size: 1.05rem;
+    font-style: italic;
+  }
+  .editorial-nav .nav-desc {
+    font-size: 0.8rem;
+    color: var(--muted);
+    letter-spacing: 0.02em;
+  }
+  .editorial-nav .nav-arrow {
+    font-size: 0.85rem;
+    color: var(--accent);
+  }
+
+  /* Footer */
+  .site-footer {
+    max-width: 720px;
+    margin: 0 auto;
+    padding: 2rem 1.5rem 3rem;
+    border-top: 1px solid var(--divider);
+    font-size: 0.8rem;
+    color: var(--muted);
+    font-style: italic;
+  }
+
+  /* ═══════════════════════════════════════
+     SECTION 2: TUNE INDEX
+     ═══════════════════════════════════════ */
+
+  .tune-index-header {
+    max-width: 720px;
+    margin: 0 auto;
+    padding: 3rem 1.5rem 0.5rem;
+  }
+  .tune-index-header h2 {
+    font-size: 1.8rem;
+    font-weight: 400;
+    font-style: italic;
+    color: var(--text);
+  }
+  .tune-index-header p {
+    font-size: 0.9rem;
+    color: var(--muted);
+    margin-top: 0.5rem;
+  }
+
+  /* Tune cards */
+  .tune-list {
+    max-width: 720px;
+    margin: 0 auto;
+    padding: 1.5rem 1.5rem 4rem;
+  }
+  .tune-entry {
+    background: var(--surface);
+    border-top: 3px solid var(--accent);
+    padding: 1.75rem 2rem 2rem;
+    margin-bottom: 2.5rem;
+  }
+  .tune-meta-line {
+    font-size: 0.72rem;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+    color: var(--accent);
+    margin-bottom: 0.5rem;
+  }
+  .tune-entry h3 {
+    font-size: 1.4rem;
+    font-weight: 400;
+    font-style: italic;
+    color: var(--text);
+    line-height: 1.35;
+  }
+  .tune-subtitle {
+    font-size: 0.85rem;
+    color: var(--muted);
+    margin-top: 0.3rem;
+    line-height: 1.5;
+  }
+  .tune-rule {
+    border: none;
+    border-top: 1px solid var(--divider);
+    margin: 1.25rem 0;
+  }
+  .chart-block {
+    background: var(--chart-bg);
+    border-left: 3px solid var(--gold);
+    padding: 1rem 1.25rem;
+    font-family: var(--font-mono);
+    font-size: 0.82rem;
+    line-height: 1.75;
+    color: var(--chart-text);
+    overflow-x: auto;
+    white-space: pre;
+  }
+  .set-note {
+    font-size: 0.82rem;
+    color: var(--muted);
+    font-style: italic;
+    margin-top: 1rem;
+  }
+
+  /* ── Responsive ── */
+  @media (max-width: 600px) {
+    .site-header {
+      flex-direction: column;
+      gap: 0.5rem;
+    }
+    .hero h2 {
+      font-size: 1.7rem;
+    }
+    .stats-row {
+      grid-template-columns: 1fr 1fr;
+      gap: 1.5rem;
+    }
+    .tune-entry {
+      padding: 1.25rem 1.25rem 1.5rem;
+    }
+    .chart-block {
+      font-size: 0.72rem;
+      padding: 0.75rem 1rem;
+    }
+  }
+</style>
+</head>
+<body>
+
+<a href="design-board.html" class="back-link">← Back to Design Board</a>
+
+<!-- ═══════════════════════════════════════════
+     SECTION 1: HOMEPAGE
+     ═══════════════════════════════════════════ -->
+
+<header class="site-header">
+  <div class="logo-group">
+    <h1>SessionBook</h1>
+    <span class="tagline">Chord charts for the session</span>
+  </div>
+  <nav>
+    <a href="#">Tunes</a>
+    <a href="#">Sets</a>
+    <a href="#">Sessions</a>
+    <a href="#">About</a>
+  </nav>
+</header>
+
+<section class="hero">
+  <h2>A home for Irish trad chord charts.</h2>
+  <div class="amber-rule"></div>
+  <p>
+    SessionBook is a quiet reference for accompanists sitting in at Irish traditional
+    music sessions. Browse chord charts by tune type, key, or set — and find your place
+    in the music without getting in the way of it.
+  </p>
+</section>
+
+<section class="stats-section">
+  <div class="stats-row">
+    <div class="stat">
+      <div class="number">142</div>
+      <div class="label">tunes charted</div>
+    </div>
+    <div class="stat">
+      <div class="number">24</div>
+      <div class="label">sets arranged</div>
+    </div>
+    <div class="stat">
+      <div class="number">6</div>
+      <div class="label">session nights</div>
+    </div>
+    <div class="stat">
+      <div class="number">5</div>
+      <div class="label">tune types</div>
+    </div>
+  </div>
+</section>
+
+<nav class="editorial-nav">
+  <ul>
+    <li>
+      <a href="#">
+        <span>
+          <span class="nav-title">Browse All Tunes</span><br>
+          <span class="nav-desc">Jigs, reels, hornpipes, polkas, and more</span>
+        </span>
+        <span class="nav-arrow">→</span>
+      </a>
+    </li>
+    <li>
+      <a href="#">
+        <span>
+          <span class="nav-title">Sets &amp; Sessions</span><br>
+          <span class="nav-desc">Curated groupings for session nights</span>
+        </span>
+        <span class="nav-arrow">→</span>
+      </a>
+    </li>
+    <li>
+      <a href="#">
+        <span>
+          <span class="nav-title">Recently Added</span><br>
+          <span class="nav-desc">The latest charts and corrections</span>
+        </span>
+        <span class="nav-arrow">→</span>
+      </a>
+    </li>
+  </ul>
+</nav>
+
+<footer class="site-footer">
+  SessionBook — a quiet companion for the session. Built with care in Dublin.
+</footer>
+
+<!-- ═══════════════════════════════════════════
+     SECTION 2: TUNE INDEX
+     ═══════════════════════════════════════════ -->
+
+<div class="section-divider"><span>Section 2</span></div>
+
+<section class="tune-index-header">
+  <h2>Tune Index</h2>
+  <p>Six tunes from the book, presented for accompanists.</p>
+</section>
+
+<div class="tune-list">
+
+  <!-- 1. Morrison's Jig -->
+  <article class="tune-entry">
+    <div class="tune-meta-line">Jig · Em Dorian · 6/8</div>
+    <h3>Morrison's Jig</h3>
+    <div class="tune-subtitle">Also known as Morrison's · Sets: Jig Set 1, First Friday December</div>
+    <hr class="tune-rule">
+    <div class="chart-block">| Em / / / | / / D / | Em / / / | C / D / |
+| Em / / / | / / D / | Em / / / | C / D / |
+| Em / / / | / / D / | C  / / / | D / / / |</div>
+    <div class="set-note">Played in Jig Set 1 and First Friday December</div>
+  </article>
+
+  <!-- 2. The Butterfly -->
+  <article class="tune-entry">
+    <div class="tune-meta-line">Jig · Em Dorian · 6/8</div>
+    <h3>The Butterfly</h3>
+    <div class="tune-subtitle">Sets: Jig Set 1</div>
+    <hr class="tune-rule">
+    <div class="chart-block">|  Em  /  /  |  /  /  D  |  Em  /  /  |  D  /  /  |
+|  Am  /  /  |  /  /  Bm  |  Am  /  /  |  /  /  Bm |
+|  Em  /  /  |  / / / | D  /  /  |  / / / |
+|  C   /  /  |  / / / | Bm /  /  |  / / / |</div>
+    <div class="set-note">Played in Jig Set 1</div>
+  </article>
+
+  <!-- 3. Swallowtail Jig -->
+  <article class="tune-entry">
+    <div class="tune-meta-line">Jig · Em Dorian · 6/8</div>
+    <h3>Swallowtail Jig</h3>
+    <div class="tune-subtitle">Sets: Jig Set 1</div>
+    <hr class="tune-rule">
+    <div class="chart-block">| Em /  /  /  |  D  /  /  /  |  Em  /  /  / |  D  /  /  Em |
+| Em /  /  /  |  /  /  /  D  |  Em  /  /  / |  /  D  /  Em  |</div>
+    <div class="set-note">Played in Jig Set 1</div>
+  </article>
+
+  <!-- 4. Saddle the Pony -->
+  <article class="tune-entry">
+    <div class="tune-meta-line">Jig · G Major · 6/8</div>
+    <h3>Saddle the Pony</h3>
+    <div class="tune-subtitle">Sets: Jig Set 2</div>
+    <hr class="tune-rule">
+    <div class="chart-block">| G  / Am / | G / D / | G / Am / | C / D G |
+| Em / / / | /  / D / | Em / / / | C / D G |</div>
+    <div class="set-note">Played in Jig Set 2</div>
+  </article>
+
+  <!-- 5. The Green Mountain -->
+  <article class="tune-entry">
+    <div class="tune-meta-line">Reel · D Major · 4/4</div>
+    <h3>The Green Mountain</h3>
+    <div class="tune-subtitle">Sets: Reel Set 1</div>
+    <hr class="tune-rule">
+    <div class="chart-block">| D / / / / | Em / G A | D / / / | Em / A D |
+| D / G / | Em / A  / | D / G / | Em  / A D |</div>
+    <div class="set-note">Played in Reel Set 1</div>
+  </article>
+
+  <!-- 6. Wind that Shakes the Barley -->
+  <article class="tune-entry">
+    <div class="tune-meta-line">Reel · D Major · 4/4</div>
+    <h3>Wind that Shakes the Barley</h3>
+    <div class="tune-subtitle">Sets: Reel Set 1</div>
+    <hr class="tune-rule">
+    <div class="chart-block"><span style="color:var(--accent);font-size:0.75em;font-style:italic">2×</span> | D / / / | G / / /  | Bm / / / | A / / / |
+<span style="color:var(--accent);font-size:0.75em;font-style:italic">1×</span> | D G D / | D G A / | D G D / | G / A / |</div>
+    <div class="set-note">Played in Reel Set 1</div>
+  </article>
+
+</div>
+
+<footer class="site-footer">
+  SessionBook — Option D: Acoustic / Editorial · Palatino serif, amber accents, magazine layout
+</footer>
+
+</body>
+</html>

--- a/design-option-e-tune.html
+++ b/design-option-e-tune.html
@@ -1,0 +1,623 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Morrison's Jig | SessionBook</title>
+<style>
+  *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+  body {
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+    background: #ffffff;
+    color: #111827;
+    line-height: 1.5;
+    -webkit-font-smoothing: antialiased;
+  }
+
+  /* Back link */
+  .back-strip {
+    display: flex;
+    align-items: center;
+    gap: .5rem;
+    padding: .75rem 1.25rem;
+    font-size: .8125rem;
+    color: #6b7280;
+    border-bottom: 1px solid #f3f4f6;
+  }
+  .back-strip a {
+    color: #6b7280;
+    text-decoration: none;
+  }
+  .back-strip a:hover { color: #111827; }
+  .back-strip .sep { color: #d1d5db; }
+
+  /* Header (repeated from option E) */
+  .site-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: .875rem 1.5rem;
+    border-bottom: 1px solid #f3f4f6;
+  }
+  .site-header .logo {
+    font-size: 1.05rem;
+    font-weight: 700;
+    color: #111827;
+    letter-spacing: -.01em;
+    text-decoration: none;
+  }
+  .site-header .tagline {
+    font-size: .75rem;
+    color: #9ca3af;
+    margin-left: .5rem;
+  }
+  .site-header nav a {
+    font-size: .8125rem;
+    color: #6b7280;
+    text-decoration: none;
+    margin-left: 1.25rem;
+  }
+  .site-header nav a:hover { color: #111827; }
+
+  /* Page container */
+  .page {
+    max-width: 52rem;
+    margin: 0 auto;
+    padding: 2rem 1.5rem 4rem;
+  }
+
+  /* Breadcrumb */
+  .breadcrumb {
+    display: flex;
+    align-items: center;
+    gap: .35rem;
+    font-size: .8125rem;
+    color: #9ca3af;
+    margin-bottom: 1.5rem;
+  }
+  .breadcrumb a {
+    color: #6b7280;
+    text-decoration: none;
+  }
+  .breadcrumb a:hover { color: #111827; }
+  .breadcrumb .sep { color: #d1d5db; }
+
+  /* Tune heading area */
+  .tune-heading {
+    margin-bottom: 1.75rem;
+  }
+  .tune-heading .badge-row {
+    display: flex;
+    align-items: center;
+    gap: .5rem;
+    margin-bottom: .5rem;
+    flex-wrap: wrap;
+  }
+  .type-badge {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: .2rem .6rem;
+    border-radius: .375rem;
+    font-size: .6875rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: .04em;
+  }
+  .type-jig { background: #fef3c7; color: #92400e; }
+  .type-reel { background: #dbeafe; color: #1e40af; }
+  .key-badge {
+    display: inline-flex;
+    align-items: center;
+    padding: .2rem .6rem;
+    border-radius: .375rem;
+    font-size: .6875rem;
+    font-weight: 600;
+    background: #f3f4f6;
+    color: #374151;
+  }
+  .meter-badge {
+    display: inline-flex;
+    align-items: center;
+    padding: .2rem .6rem;
+    border-radius: .375rem;
+    font-size: .6875rem;
+    font-weight: 600;
+    background: #f3f4f6;
+    color: #374151;
+  }
+  .tune-heading h1 {
+    font-size: 1.75rem;
+    font-weight: 700;
+    letter-spacing: -.02em;
+    line-height: 1.2;
+    margin-bottom: .35rem;
+  }
+  .tune-heading .aliases {
+    font-size: .875rem;
+    color: #9ca3af;
+    font-style: italic;
+  }
+
+  /* Chart display — the star of the page */
+  .chart-section {
+    margin-bottom: 2rem;
+  }
+  .chart-section .section-label {
+    font-size: .6875rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: .06em;
+    color: #9ca3af;
+    margin-bottom: .5rem;
+  }
+  .chart-block {
+    background: #f9fafb;
+    border: 1px solid #e5e7eb;
+    border-radius: .5rem;
+    padding: 1.25rem 1.5rem;
+    font-family: 'SF Mono', 'Fira Code', 'Cascadia Code', 'Menlo', monospace;
+    font-size: .875rem;
+    line-height: 2;
+    color: #1f2937;
+    white-space: pre;
+    overflow-x: auto;
+  }
+  .chart-block .part-label {
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+    font-size: .6875rem;
+    font-weight: 700;
+    color: #9ca3af;
+    text-transform: uppercase;
+    letter-spacing: .05em;
+    display: block;
+    margin-bottom: .125rem;
+    margin-top: .75rem;
+  }
+  .chart-block .part-label:first-child {
+    margin-top: 0;
+  }
+
+  /* Metadata grid */
+  .meta-grid {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 1rem;
+    margin-bottom: 2rem;
+  }
+  .meta-card {
+    padding: 1rem;
+    background: #f9fafb;
+    border: 1px solid #e5e7eb;
+    border-radius: .5rem;
+  }
+  .meta-card .meta-label {
+    font-size: .6875rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: .06em;
+    color: #9ca3af;
+    margin-bottom: .35rem;
+  }
+  .meta-card .meta-value {
+    font-size: .9375rem;
+    font-weight: 600;
+    color: #111827;
+  }
+  .meta-card .meta-sub {
+    font-size: .8125rem;
+    color: #6b7280;
+    margin-top: .15rem;
+  }
+
+  /* Sets section */
+  .sets-section {
+    margin-bottom: 2rem;
+  }
+  .sets-section .section-label {
+    font-size: .6875rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: .06em;
+    color: #9ca3af;
+    margin-bottom: .75rem;
+  }
+  .set-card {
+    border: 1px solid #e5e7eb;
+    border-radius: .5rem;
+    overflow: hidden;
+    margin-bottom: .75rem;
+  }
+  .set-card-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: .75rem 1rem;
+    background: #f9fafb;
+    border-bottom: 1px solid #f3f4f6;
+  }
+  .set-card-header .set-name {
+    font-size: .9375rem;
+    font-weight: 600;
+    color: #111827;
+  }
+  .set-card-header .set-count {
+    font-size: .75rem;
+    color: #9ca3af;
+  }
+  .set-entry-list {
+    list-style: none;
+  }
+  .set-entry {
+    display: grid;
+    grid-template-columns: 1.75rem 2rem 1fr auto;
+    gap: .5rem;
+    align-items: center;
+    padding: .5rem 1rem;
+    border-bottom: 1px solid #f3f4f6;
+    font-size: .8125rem;
+  }
+  .set-entry:last-child { border-bottom: none; }
+  .set-entry .pos {
+    font-size: .75rem;
+    font-weight: 600;
+    color: #9ca3af;
+    text-align: center;
+  }
+  .set-entry .entry-badge {
+    width: 2rem;
+    height: 1.5rem;
+    border-radius: .25rem;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: .5rem;
+    font-weight: 700;
+    text-transform: uppercase;
+  }
+  .set-entry .entry-name {
+    font-weight: 500;
+    color: #111827;
+  }
+  .set-entry .entry-name.current {
+    font-weight: 700;
+    color: #111827;
+  }
+  .set-entry .entry-key {
+    font-size: .75rem;
+    color: #9ca3af;
+    text-align: right;
+  }
+  .set-entry.is-current {
+    background: #fffbeb;
+  }
+
+  /* Notes section */
+  .notes-section {
+    margin-bottom: 2rem;
+    padding: 1rem 1.25rem;
+    background: #fffbeb;
+    border: 1px solid #fef3c7;
+    border-radius: .5rem;
+  }
+  .notes-section .section-label {
+    font-size: .6875rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: .06em;
+    color: #92400e;
+    margin-bottom: .35rem;
+  }
+  .notes-section p {
+    font-size: .875rem;
+    color: #78716c;
+    line-height: 1.6;
+  }
+
+  /* Related tunes */
+  .related-section {
+    margin-bottom: 2rem;
+  }
+  .related-section .section-label {
+    font-size: .6875rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: .06em;
+    color: #9ca3af;
+    margin-bottom: .75rem;
+  }
+  .related-list {
+    border-top: 1px solid #e5e7eb;
+  }
+  .related-row {
+    display: grid;
+    grid-template-columns: 2rem 1fr auto;
+    gap: .75rem;
+    align-items: center;
+    padding: .5rem 0;
+    border-bottom: 1px solid #f3f4f6;
+    text-decoration: none;
+    color: inherit;
+    transition: background .1s;
+  }
+  .related-row:hover {
+    background: #f9fafb;
+    margin: 0 -.5rem;
+    padding-left: .5rem;
+    padding-right: .5rem;
+  }
+  .related-badge {
+    width: 2rem;
+    height: 2rem;
+    border-radius: .375rem;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: .5rem;
+    font-weight: 700;
+    text-transform: uppercase;
+  }
+  .related-row .r-name {
+    font-size: .875rem;
+    font-weight: 600;
+    color: #111827;
+  }
+  .related-row .r-sub {
+    font-size: .75rem;
+    color: #9ca3af;
+  }
+  .related-row .r-meta {
+    font-size: .75rem;
+    color: #9ca3af;
+    text-align: right;
+  }
+
+  /* Footer nav */
+  .page-nav {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding-top: 1.5rem;
+    border-top: 1px solid #e5e7eb;
+    margin-top: 2rem;
+  }
+  .page-nav a {
+    font-size: .8125rem;
+    font-weight: 600;
+    color: #6b7280;
+    text-decoration: none;
+    transition: color .15s;
+  }
+  .page-nav a:hover { color: #111827; }
+  .page-nav .next { text-align: right; }
+  .page-nav .nav-label {
+    font-size: .6875rem;
+    font-weight: 400;
+    color: #9ca3af;
+    display: block;
+    margin-bottom: .1rem;
+  }
+
+  /* Responsive */
+  @media (max-width: 640px) {
+    .site-header { padding: .75rem 1rem; }
+    .site-header .tagline { display: none; }
+    .page { padding: 1.5rem 1rem 3rem; }
+    .tune-heading h1 { font-size: 1.35rem; }
+    .meta-grid { grid-template-columns: 1fr; }
+    .chart-block { font-size: .75rem; padding: 1rem; }
+    .set-entry { grid-template-columns: 1.5rem 1.75rem 1fr auto; gap: .35rem; font-size: .75rem; }
+  }
+</style>
+</head>
+<body>
+
+<a href="design-board.html" class="back-strip" style="border-bottom:none">← Back to Design Board</a>
+
+<!-- Header -->
+<header class="site-header">
+  <div style="display:flex;align-items:baseline;">
+    <a class="logo" href="design-option-e.html">SessionBook</a>
+    <span class="tagline">Irish trad chord charts</span>
+  </div>
+  <nav>
+    <a href="design-option-e.html#tune-index">Tunes</a>
+    <a href="#">Sets</a>
+    <a href="#">About</a>
+  </nav>
+</header>
+
+<div class="page">
+
+  <!-- Breadcrumb -->
+  <nav class="breadcrumb">
+    <a href="design-option-e.html">Home</a>
+    <span class="sep">/</span>
+    <a href="design-option-e.html#tune-index">Tunes</a>
+    <span class="sep">/</span>
+    <span>Morrison's Jig</span>
+  </nav>
+
+  <!-- Tune heading -->
+  <div class="tune-heading">
+    <div class="badge-row">
+      <span class="type-badge type-jig">Jig</span>
+      <span class="key-badge">Em Dorian</span>
+      <span class="meter-badge">6/8</span>
+    </div>
+    <h1>Morrison's Jig</h1>
+    <div class="aliases">Also known as: Morrison's</div>
+  </div>
+
+  <!-- Chart — the hero of the page -->
+  <div class="chart-section">
+    <div class="section-label">Chord Chart — Standard</div>
+    <div class="chart-block"><span class="part-label">Part A</span>
+| Em  /  /  / | /  /  D  / | Em  /  /  / | C  /  D  / |
+| Em  /  /  / | /  /  D  / | Em  /  /  / | C  /  D  / |
+<span class="part-label">Part B</span>
+| Em  /  /  / | /  /  D  / | C   /  /  / | D  /  /  / |</div>
+  </div>
+
+  <!-- Metadata cards -->
+  <div class="meta-grid">
+    <div class="meta-card">
+      <div class="meta-label">Key &amp; Mode</div>
+      <div class="meta-value">Em Dorian</div>
+      <div class="meta-sub">Common Irish session tuning</div>
+    </div>
+    <div class="meta-card">
+      <div class="meta-label">Meter</div>
+      <div class="meta-value">6/8</div>
+      <div class="meta-sub">Jig time — two groups of three</div>
+    </div>
+    <div class="meta-card">
+      <div class="meta-label">Tune Type</div>
+      <div class="meta-value">Jig</div>
+      <div class="meta-sub">Double jig</div>
+    </div>
+    <div class="meta-card">
+      <div class="meta-label">Aliases</div>
+      <div class="meta-value">Morrison's</div>
+      <div class="meta-sub">1 alternate name</div>
+    </div>
+  </div>
+
+  <!-- Sets this tune appears in -->
+  <div class="sets-section">
+    <div class="section-label">Appears in 2 sets</div>
+
+    <div class="set-card">
+      <div class="set-card-header">
+        <span class="set-name">Jig Set 1</span>
+        <span class="set-count">3 tunes</span>
+      </div>
+      <ul class="set-entry-list">
+        <li class="set-entry is-current">
+          <span class="pos">1</span>
+          <span class="entry-badge type-jig">Jig</span>
+          <span class="entry-name current">Morrison's Jig ←</span>
+          <span class="entry-key">Em Dorian</span>
+        </li>
+        <li class="set-entry">
+          <span class="pos">2</span>
+          <span class="entry-badge type-jig">Jig</span>
+          <span class="entry-name">The Butterfly</span>
+          <span class="entry-key">Em Dorian</span>
+        </li>
+        <li class="set-entry">
+          <span class="pos">3</span>
+          <span class="entry-badge type-jig">Jig</span>
+          <span class="entry-name">Swallowtail Jig</span>
+          <span class="entry-key">Em Dorian</span>
+        </li>
+      </ul>
+    </div>
+
+    <div class="set-card">
+      <div class="set-card-header">
+        <span class="set-name">First Friday December</span>
+        <span class="set-count">5 tunes</span>
+      </div>
+      <ul class="set-entry-list">
+        <li class="set-entry is-current">
+          <span class="pos">1</span>
+          <span class="entry-badge type-jig">Jig</span>
+          <span class="entry-name current">Morrison's Jig ←</span>
+          <span class="entry-key">Em Dorian</span>
+        </li>
+        <li class="set-entry">
+          <span class="pos">2</span>
+          <span class="entry-badge type-jig">Jig</span>
+          <span class="entry-name">Saddle the Pony</span>
+          <span class="entry-key">G Major</span>
+        </li>
+        <li class="set-entry">
+          <span class="pos">3</span>
+          <span class="entry-badge type-jig">Jig</span>
+          <span class="entry-name">Lilting Banshee</span>
+          <span class="entry-key">A Dorian</span>
+        </li>
+        <li class="set-entry">
+          <span class="pos">4</span>
+          <span class="entry-badge type-reel">Reel</span>
+          <span class="entry-name">The Green Mountain</span>
+          <span class="entry-key">D Major</span>
+        </li>
+        <li class="set-entry">
+          <span class="pos">5</span>
+          <span class="entry-badge type-reel">Reel</span>
+          <span class="entry-name">Wind that Shakes the Barley</span>
+          <span class="entry-key">D Major</span>
+        </li>
+      </ul>
+    </div>
+  </div>
+
+  <!-- Notes -->
+  <div class="notes-section">
+    <div class="section-label">Session Notes</div>
+    <p>A staple session jig. Part A repeats; Part B typically only once before returning to A. Often paired with The Butterfly or Swallowtail Jig in a set of three.</p>
+  </div>
+
+  <!-- Related tunes (others from same sets) -->
+  <div class="related-section">
+    <div class="section-label">Other tunes in the same sets</div>
+    <div class="related-list">
+      <a class="related-row" href="#">
+        <div class="related-badge type-jig">Jig</div>
+        <div>
+          <div class="r-name">The Butterfly</div>
+          <div class="r-sub">Jig Set 1</div>
+        </div>
+        <div class="r-meta">Em Dorian</div>
+      </a>
+      <a class="related-row" href="#">
+        <div class="related-badge type-jig">Jig</div>
+        <div>
+          <div class="r-name">Swallowtail Jig</div>
+          <div class="r-sub">Jig Set 1</div>
+        </div>
+        <div class="r-meta">Em Dorian</div>
+      </a>
+      <a class="related-row" href="#">
+        <div class="related-badge type-jig">Jig</div>
+        <div>
+          <div class="r-name">Saddle the Pony</div>
+          <div class="r-sub">First Friday December</div>
+        </div>
+        <div class="r-meta">G Major</div>
+      </a>
+      <a class="related-row" href="#">
+        <div class="related-badge type-jig">Jig</div>
+        <div>
+          <div class="r-name">Lilting Banshee</div>
+          <div class="r-sub">First Friday December</div>
+        </div>
+        <div class="r-meta">A Dorian</div>
+      </a>
+      <a class="related-row" href="#">
+        <div class="related-badge type-reel">Reel</div>
+        <div>
+          <div class="r-name">The Green Mountain</div>
+          <div class="r-sub">First Friday December</div>
+        </div>
+        <div class="r-meta">D Major</div>
+      </a>
+    </div>
+  </div>
+
+  <!-- Prev / Next navigation -->
+  <nav class="page-nav">
+    <div><!-- no previous, first tune --></div>
+    <a href="#" class="next">
+      <span class="nav-label">Next tune</span>
+      The Butterfly →
+    </a>
+  </nav>
+
+</div>
+
+</body>
+</html>

--- a/design-option-e.html
+++ b/design-option-e.html
@@ -1,0 +1,536 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>SessionBook — Option E: Compact Index</title>
+<style>
+  *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+  body {
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+    background: #ffffff;
+    color: #111827;
+    line-height: 1.5;
+    -webkit-font-smoothing: antialiased;
+  }
+
+  /* Back link */
+  .back-link {
+    display: inline-block;
+    padding: .75rem 1.25rem;
+    font-size: .8125rem;
+    color: #6b7280;
+    text-decoration: none;
+  }
+  .back-link:hover { color: #111827; }
+
+  /* ── SECTION 1 — HOMEPAGE ── */
+
+  .site-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: .875rem 1.5rem;
+    border-bottom: 1px solid #f3f4f6;
+  }
+  .site-header .logo {
+    font-size: 1.05rem;
+    font-weight: 700;
+    color: #111827;
+    letter-spacing: -.01em;
+  }
+  .site-header .tagline {
+    font-size: .75rem;
+    color: #9ca3af;
+    margin-left: .5rem;
+  }
+  .site-header nav a {
+    font-size: .8125rem;
+    color: #6b7280;
+    text-decoration: none;
+    margin-left: 1.25rem;
+  }
+  .site-header nav a:hover { color: #111827; }
+
+  .hero {
+    max-width: 42rem;
+    margin: 0 auto;
+    padding: 3rem 1.5rem 2rem;
+    text-align: center;
+  }
+  .hero h1 {
+    font-size: 1.75rem;
+    font-weight: 700;
+    letter-spacing: -.02em;
+    margin-bottom: .5rem;
+  }
+  .hero p {
+    color: #6b7280;
+    font-size: .9375rem;
+    margin-bottom: 1.5rem;
+    max-width: 32rem;
+    margin-left: auto;
+    margin-right: auto;
+  }
+  .hero-actions {
+    display: flex;
+    gap: .625rem;
+    justify-content: center;
+    flex-wrap: wrap;
+  }
+  .btn {
+    display: inline-block;
+    padding: .5rem 1.125rem;
+    font-size: .8125rem;
+    font-weight: 600;
+    border-radius: .375rem;
+    text-decoration: none;
+    cursor: pointer;
+    border: none;
+    transition: background .15s;
+  }
+  .btn-primary {
+    background: #111827;
+    color: #fff;
+  }
+  .btn-primary:hover { background: #1f2937; }
+  .btn-secondary {
+    background: #f3f4f6;
+    color: #374151;
+  }
+  .btn-secondary:hover { background: #e5e7eb; }
+
+  .stats-bar {
+    display: flex;
+    justify-content: center;
+    gap: 2rem;
+    padding: .75rem 1.5rem 1.75rem;
+    font-size: .8125rem;
+    color: #9ca3af;
+  }
+  .stats-bar strong {
+    color: #111827;
+    font-weight: 600;
+  }
+
+  .quick-links {
+    display: flex;
+    justify-content: center;
+    gap: .5rem;
+    padding-bottom: 2.5rem;
+    border-bottom: 1px solid #f3f4f6;
+  }
+  .quick-link {
+    font-size: .8125rem;
+    color: #6b7280;
+    text-decoration: none;
+    padding: .375rem .875rem;
+    border: 1px solid #e5e7eb;
+    border-radius: .375rem;
+    transition: all .15s;
+  }
+  .quick-link:hover {
+    border-color: #d1d5db;
+    color: #111827;
+    background: #f9fafb;
+  }
+
+  /* ── SECTION 2 — TUNE INDEX ── */
+
+  .index-section {
+    max-width: 52rem;
+    margin: 0 auto;
+    padding: 2.5rem 1.5rem 4rem;
+  }
+
+  .index-header {
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    margin-bottom: .25rem;
+    flex-wrap: wrap;
+    gap: .5rem;
+  }
+  .index-header h1 {
+    font-size: 1.35rem;
+    font-weight: 700;
+    letter-spacing: -.015em;
+  }
+  .index-header .filter-hint {
+    font-size: .75rem;
+    color: #9ca3af;
+  }
+  .index-subtitle {
+    font-size: .8125rem;
+    color: #6b7280;
+    margin-bottom: 1.25rem;
+  }
+
+  /* Tune rows */
+  .tune-list {
+    border-top: 1px solid #e5e7eb;
+  }
+
+  .tune-row {
+    display: grid;
+    grid-template-columns: 2.5rem 1fr auto;
+    gap: .875rem;
+    align-items: center;
+    padding: .625rem 0;
+    border-bottom: 1px solid #f3f4f6;
+    cursor: pointer;
+    transition: background .1s;
+  }
+  .tune-row:hover {
+    background: #f9fafb;
+    margin: 0 -.75rem;
+    padding-left: .75rem;
+    padding-right: .75rem;
+  }
+
+  /* Type badge */
+  .type-badge {
+    width: 2.5rem;
+    height: 2.5rem;
+    border-radius: .375rem;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: .625rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: .03em;
+    flex-shrink: 0;
+    user-select: none;
+  }
+  .type-jig      { background: #fef3c7; color: #92400e; }
+  .type-reel     { background: #dbeafe; color: #1e40af; }
+  .type-hornpipe { background: #fce7f3; color: #9d174d; }
+  .type-polka    { background: #d1fae5; color: #065f46; }
+
+  /* Tune info */
+  .tune-info .tune-name {
+    font-size: .9375rem;
+    font-weight: 600;
+    color: #111827;
+    line-height: 1.3;
+  }
+  .tune-info .tune-sub {
+    font-size: .75rem;
+    color: #9ca3af;
+    line-height: 1.35;
+  }
+
+  /* Tune meta (right) */
+  .tune-meta {
+    text-align: right;
+    flex-shrink: 0;
+    white-space: nowrap;
+  }
+  .tune-meta .key-mode {
+    font-size: .8125rem;
+    font-weight: 500;
+    color: #374151;
+  }
+  .tune-meta .meter {
+    font-size: .6875rem;
+    color: #9ca3af;
+  }
+
+  /* Expanded chart */
+  .tune-chart {
+    display: none;
+    padding: .875rem 1rem;
+    margin: 0 0 .125rem 0;
+    background: #f9fafb;
+    border: 1px solid #e5e7eb;
+    border-radius: .375rem;
+    font-family: 'SF Mono', 'Fira Code', 'Cascadia Code', 'Menlo', monospace;
+    font-size: .75rem;
+    line-height: 1.7;
+    color: #374151;
+    white-space: pre;
+    overflow-x: auto;
+  }
+  .tune-chart.expanded {
+    display: block;
+  }
+  .tune-chart .chart-label {
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+    font-size: .6875rem;
+    font-weight: 600;
+    color: #9ca3af;
+    text-transform: uppercase;
+    letter-spacing: .05em;
+    margin-bottom: .375rem;
+    display: block;
+  }
+
+  .section-divider {
+    border: none;
+    border-top: 1px solid #e5e7eb;
+    margin: 0;
+  }
+
+  /* Responsive */
+  @media (max-width: 640px) {
+    .site-header { padding: .75rem 1rem; }
+    .site-header .tagline { display: none; }
+    .hero { padding: 2rem 1rem 1.5rem; }
+    .hero h1 { font-size: 1.375rem; }
+    .stats-bar { gap: 1rem; font-size: .75rem; }
+    .index-section { padding: 1.5rem 1rem 3rem; }
+    .tune-row { gap: .625rem; }
+    .tune-meta .key-mode { font-size: .75rem; }
+  }
+</style>
+</head>
+<body>
+
+<a href="design-board.html" class="back-link">← Back to Design Board</a>
+
+<!-- ════════════════════════════════════════════
+     SECTION 1 — HOMEPAGE
+     ════════════════════════════════════════════ -->
+
+<header class="site-header">
+  <div style="display:flex;align-items:baseline;">
+    <span class="logo">SessionBook</span>
+    <span class="tagline">Irish trad chord charts</span>
+  </div>
+  <nav>
+    <a href="#tunes">Tunes</a>
+    <a href="#sets">Sets</a>
+    <a href="#about">About</a>
+  </nav>
+</header>
+
+<section class="hero">
+  <h1>Chord charts for the session</h1>
+  <p>Quick-reference chord progressions for Irish traditional tunes. Built for guitarists, bouzouki players, and anyone comping at the session.</p>
+  <div class="hero-actions">
+    <a href="#tune-index" class="btn btn-primary">Browse Tunes</a>
+    <a href="#sets" class="btn btn-secondary">View Sets</a>
+  </div>
+</section>
+
+<div class="stats-bar">
+  <span><strong>12</strong> tunes</span>
+  <span><strong>4</strong> sets</span>
+  <span><strong>2</strong> types</span>
+</div>
+
+<div class="quick-links">
+  <a href="#tune-index" class="quick-link">All Tunes</a>
+  <a href="#jigs" class="quick-link">Jigs</a>
+  <a href="#reels" class="quick-link">Reels</a>
+  <a href="#sets" class="quick-link">Sets</a>
+</div>
+
+<hr class="section-divider">
+
+<!-- ════════════════════════════════════════════
+     SECTION 2 — TUNE INDEX
+     ════════════════════════════════════════════ -->
+
+<section class="index-section" id="tune-index">
+
+  <div class="index-header">
+    <h1>Tunes</h1>
+    <span class="filter-hint">Sort by name · Filter by type</span>
+  </div>
+  <p class="index-subtitle">12 tunes across jigs, reels, and more. Click a row to view its chord chart.</p>
+
+  <div class="tune-list">
+
+    <!-- 1. Morrison's Jig — EXPANDED -->
+    <div class="tune-row" onclick="toggle('chart-morrisons')" style="background:#f9fafb;margin:0 -.75rem;padding-left:.75rem;padding-right:.75rem;">
+      <div class="type-badge type-jig">Jig</div>
+      <div class="tune-info">
+        <div class="tune-name"><a href="design-option-e-tune.html" style="color:inherit;text-decoration:none;border-bottom:1px solid #e5e7eb">Morrison's Jig</a></div>
+        <div class="tune-sub">Morrison's · Sets: Jig Set 1, First Friday December</div>
+      </div>
+      <div class="tune-meta">
+        <div class="key-mode">Em Dorian</div>
+        <div class="meter">6/8</div>
+      </div>
+    </div>
+    <div class="tune-chart expanded" id="chart-morrisons"><span class="chart-label">Chord Chart</span>
+| Em  /  /  / | /  /  D  / | Em  /  /  / | C  /  D  / |
+| Em  /  /  / | /  /  D  / | Em  /  /  / | C  /  D  / |
+| Em  /  /  / | /  /  D  / | C   /  /  / | D  /  /  / |</div>
+
+    <!-- 2. The Butterfly -->
+    <div class="tune-row" onclick="toggle('chart-butterfly')">
+      <div class="type-badge type-jig">Jig</div>
+      <div class="tune-info">
+        <div class="tune-name">The Butterfly</div>
+        <div class="tune-sub">Sets: Jig Set 1</div>
+      </div>
+      <div class="tune-meta">
+        <div class="key-mode">Em Dorian</div>
+        <div class="meter">6/8</div>
+      </div>
+    </div>
+    <div class="tune-chart" id="chart-butterfly"><span class="chart-label">Chord Chart</span>
+| Em  /  /  | /  /  D  | Em  /  /  | D  /  /  |
+| Am  /  /  | /  /  Bm | Am  /  /  | /  /  Bm |
+| Em  /  /  | /  /  /  | D   /  /  | /  /  /  |
+| C   /  /  | /  /  /  | Bm  /  /  | /  /  /  |</div>
+
+    <!-- 3. Swallowtail Jig -->
+    <div class="tune-row" onclick="toggle('chart-swallowtail')">
+      <div class="type-badge type-jig">Jig</div>
+      <div class="tune-info">
+        <div class="tune-name">Swallowtail Jig</div>
+        <div class="tune-sub">Sets: Jig Set 1</div>
+      </div>
+      <div class="tune-meta">
+        <div class="key-mode">Em Dorian</div>
+        <div class="meter">6/8</div>
+      </div>
+    </div>
+    <div class="tune-chart" id="chart-swallowtail"><span class="chart-label">Chord Chart</span>
+| Em  /  /  / | D   /  /  / | Em  /  /  / | D  /  /  Em |
+| Em  /  /  / | /   /  /  D | Em  /  /  / | /  D  /  Em |</div>
+
+    <!-- 4. Saddle the Pony -->
+    <div class="tune-row" onclick="toggle('chart-saddle')">
+      <div class="type-badge type-jig">Jig</div>
+      <div class="tune-info">
+        <div class="tune-name">Saddle the Pony</div>
+        <div class="tune-sub">Sets: Jig Set 2</div>
+      </div>
+      <div class="tune-meta">
+        <div class="key-mode">G Major</div>
+        <div class="meter">6/8</div>
+      </div>
+    </div>
+    <div class="tune-chart" id="chart-saddle"><span class="chart-label">Chord Chart</span>
+| G  /  Am  / | G  /  D  / | G  /  Am  / | C  /  D  G |
+| Em /  /   / | /  /  D  / | Em /  /   / | C  /  D  G |</div>
+
+    <!-- 5. The Green Mountain -->
+    <div class="tune-row" onclick="toggle('chart-greenmtn')">
+      <div class="type-badge type-reel">Reel</div>
+      <div class="tune-info">
+        <div class="tune-name">The Green Mountain</div>
+        <div class="tune-sub">Sets: Reel Set 1</div>
+      </div>
+      <div class="tune-meta">
+        <div class="key-mode">D Major</div>
+        <div class="meter">4/4</div>
+      </div>
+    </div>
+    <div class="tune-chart" id="chart-greenmtn"><span class="chart-label">Chord Chart</span>
+| D  /  /  / | Em  /  G  A | D  /  /  / | Em  /  A  D |
+| D  /  G  / | Em  /  A  / | D  /  G  / | Em  /  A  D |</div>
+
+    <!-- 6. Wind that Shakes the Barley -->
+    <div class="tune-row" onclick="toggle('chart-wind')">
+      <div class="type-badge type-reel">Reel</div>
+      <div class="tune-info">
+        <div class="tune-name">Wind that Shakes the Barley</div>
+        <div class="tune-sub">Sets: Reel Set 1</div>
+      </div>
+      <div class="tune-meta">
+        <div class="key-mode">D Major</div>
+        <div class="meter">4/4</div>
+      </div>
+    </div>
+    <div class="tune-chart" id="chart-wind"><span class="chart-label">Chord Chart</span>
+{2x}| D  /  /  / | G  /  /  / | Bm  /  /  / | A  /  /  / |
+{1x}| D  G  D  / | D  G  A  / | D   G  D  / | G  /  A  / |</div>
+
+    <!-- 7. Swinging on the Gate -->
+    <div class="tune-row">
+      <div class="type-badge type-reel">Reel</div>
+      <div class="tune-info">
+        <div class="tune-name">Swinging on the Gate</div>
+        <div class="tune-sub"></div>
+      </div>
+      <div class="tune-meta">
+        <div class="key-mode">G Major</div>
+        <div class="meter">4/4</div>
+      </div>
+    </div>
+
+    <!-- 8. Man of the House -->
+    <div class="tune-row">
+      <div class="type-badge type-reel">Reel</div>
+      <div class="tune-info">
+        <div class="tune-name">Man of the House</div>
+        <div class="tune-sub"></div>
+      </div>
+      <div class="tune-meta">
+        <div class="key-mode">Em Dorian</div>
+        <div class="meter">4/4</div>
+      </div>
+    </div>
+
+    <!-- 9. Connaughtman's Rambles -->
+    <div class="tune-row">
+      <div class="type-badge type-reel">Reel</div>
+      <div class="tune-info">
+        <div class="tune-name">Connaughtman's Rambles</div>
+        <div class="tune-sub"></div>
+      </div>
+      <div class="tune-meta">
+        <div class="key-mode">D Major</div>
+        <div class="meter">4/4</div>
+      </div>
+    </div>
+
+    <!-- 10. Lilting Banshee -->
+    <div class="tune-row">
+      <div class="type-badge type-jig">Jig</div>
+      <div class="tune-info">
+        <div class="tune-name">Lilting Banshee</div>
+        <div class="tune-sub"></div>
+      </div>
+      <div class="tune-meta">
+        <div class="key-mode">A Dorian</div>
+        <div class="meter">6/8</div>
+      </div>
+    </div>
+
+    <!-- 11. Tom Billy's -->
+    <div class="tune-row">
+      <div class="type-badge type-jig">Jig</div>
+      <div class="tune-info">
+        <div class="tune-name">Tom Billy's</div>
+        <div class="tune-sub"></div>
+      </div>
+      <div class="tune-meta">
+        <div class="key-mode">A Major</div>
+        <div class="meter">6/8</div>
+      </div>
+    </div>
+
+    <!-- 12. The Rolling Waves -->
+    <div class="tune-row">
+      <div class="type-badge type-reel">Reel</div>
+      <div class="tune-info">
+        <div class="tune-name">The Rolling Waves</div>
+        <div class="tune-sub"></div>
+      </div>
+      <div class="tune-meta">
+        <div class="key-mode">D Major</div>
+        <div class="meter">4/4</div>
+      </div>
+    </div>
+
+  </div><!-- .tune-list -->
+</section>
+
+<script>
+function toggle(id) {
+  var el = document.getElementById(id);
+  if (!el) return;
+  el.classList.toggle('expanded');
+}
+</script>
+
+</body>
+</html>

--- a/design-option-f.html
+++ b/design-option-f.html
@@ -1,0 +1,448 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>SessionBook — Option F: Music Paper</title>
+<style>
+  *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+  :root {
+    --font: 'Courier New', Courier, monospace;
+    --bg: #fffef7;
+    --text: #1a1a1a;
+    --muted: #555555;
+    --accent: #8b5e3c;
+    --dashed: #c9b99a;
+    --chart-bg: rgba(255, 255, 240, 0.6);
+    --line-height: 1.5rem;
+  }
+
+  html { font-size: 16px; }
+
+  body {
+    font-family: var(--font);
+    color: var(--text);
+    background-color: var(--bg);
+    background-image: repeating-linear-gradient(
+      transparent, transparent 1.45rem, #e8e4d8 1.45rem, #e8e4d8 1.5rem
+    );
+    line-height: var(--line-height);
+    min-height: 100vh;
+    -webkit-font-smoothing: antialiased;
+  }
+
+  .page {
+    max-width: 52rem;
+    margin: 0 auto;
+    padding: 1.5rem 2rem 3rem;
+  }
+
+  /* ---- Back link ---- */
+  .back-link {
+    display: inline-block;
+    font-size: 0.8rem;
+    color: var(--accent);
+    text-decoration: none;
+    margin-bottom: 1.5rem;
+    letter-spacing: 0.02em;
+  }
+  .back-link:hover { text-decoration: underline; }
+
+  /* ---- Design label ---- */
+  .design-label {
+    display: inline-block;
+    border: 2px solid var(--accent);
+    color: var(--accent);
+    font-size: 0.65rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.12em;
+    padding: 0.15rem 0.6rem;
+    transform: rotate(-1.5deg);
+    margin-bottom: 1.5rem;
+  }
+
+  /* ---- Section divider ---- */
+  .section-divider {
+    border: none;
+    border-top: 2px dashed var(--dashed);
+    margin: 3rem 0;
+  }
+
+  /* ============================================
+     SECTION 1: HOMEPAGE
+     ============================================ */
+
+  /* Notebook cover header */
+  .notebook-header {
+    margin-bottom: 3rem;
+    padding-bottom: 1.5rem;
+    border-bottom: 1px solid var(--dashed);
+  }
+  .notebook-header__title {
+    font-size: 2.4rem;
+    font-weight: 700;
+    line-height: 3rem;
+    letter-spacing: -0.02em;
+    color: var(--text);
+  }
+  .notebook-header__subtitle {
+    font-size: 0.85rem;
+    font-weight: 400;
+    color: var(--muted);
+    margin-top: 0.25rem;
+  }
+  .notebook-header__nav {
+    margin-top: 1.5rem;
+    display: flex;
+    gap: 1.5rem;
+    flex-wrap: wrap;
+  }
+  .notebook-header__nav a {
+    color: var(--accent);
+    text-decoration: none;
+    font-size: 0.85rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+  }
+  .notebook-header__nav a:hover { text-decoration: underline; }
+
+  /* Hero */
+  .hero { margin-bottom: 3rem; }
+  .hero__heading {
+    font-size: 1.5rem;
+    font-weight: 700;
+    line-height: 3rem;
+    margin-bottom: 1.5rem;
+  }
+  .hero__text {
+    color: var(--muted);
+    font-size: 0.9rem;
+    max-width: 40rem;
+    margin-bottom: 1.5rem;
+  }
+
+  /* Stats — margin notes */
+  .stats {
+    display: flex;
+    gap: 3rem;
+    flex-wrap: wrap;
+    margin-bottom: 3rem;
+    padding-left: 0.5rem;
+  }
+  .stat {
+    position: relative;
+    padding-left: 1rem;
+  }
+  .stat::before {
+    content: '|';
+    position: absolute;
+    left: 0;
+    top: 0;
+    color: var(--dashed);
+    font-weight: 700;
+  }
+  .stat__number {
+    font-size: 1.6rem;
+    font-weight: 700;
+    color: var(--accent);
+    line-height: 1.5rem;
+  }
+  .stat__label {
+    font-size: 0.75rem;
+    color: var(--muted);
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+  }
+
+  /* Section links */
+  .section-links { margin-bottom: 3rem; }
+  .section-links__heading {
+    font-size: 0.8rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.1em;
+    color: var(--muted);
+    margin-bottom: 0.75rem;
+  }
+  .section-links ul {
+    list-style: none;
+    padding: 0;
+  }
+  .section-links li {
+    line-height: var(--line-height);
+  }
+  .section-links a {
+    color: var(--accent);
+    text-decoration: underline;
+    text-underline-offset: 2px;
+    font-size: 0.9rem;
+  }
+  .section-links a:hover { color: var(--text); }
+
+  /* Footer */
+  .page-footer {
+    text-align: center;
+    color: var(--dashed);
+    font-size: 0.75rem;
+    padding-top: 1.5rem;
+    letter-spacing: 0.08em;
+  }
+
+  /* ============================================
+     SECTION 2: TUNE INDEX
+     ============================================ */
+
+  .tune-index__heading {
+    font-size: 1.3rem;
+    font-weight: 700;
+    margin-bottom: 0.25rem;
+  }
+  .tune-index__sub {
+    font-size: 0.8rem;
+    color: var(--muted);
+    margin-bottom: 3rem;
+  }
+
+  /* Tune entry */
+  .tune-entry {
+    margin-bottom: 3rem;
+    padding-bottom: 1.5rem;
+  }
+
+  /* Rubber stamp badge */
+  .stamp {
+    display: inline-block;
+    border: 2px solid var(--accent);
+    color: var(--accent);
+    font-size: 0.65rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.1em;
+    padding: 0.1rem 0.5rem;
+    transform: rotate(-1deg);
+    margin-bottom: 0.375rem;
+  }
+  .tune-entry:nth-child(even) .stamp { transform: rotate(0.8deg); }
+  .tune-entry:nth-child(3n) .stamp { transform: rotate(-0.5deg); }
+
+  .tune-entry__name {
+    font-size: 1.1rem;
+    font-weight: 700;
+    line-height: var(--line-height);
+    margin-bottom: 0.25rem;
+  }
+
+  .tune-entry__info {
+    font-size: 0.8rem;
+    color: var(--muted);
+    margin-bottom: 0.25rem;
+    line-height: var(--line-height);
+  }
+  .tune-entry__info span { margin-right: 1rem; }
+
+  .tune-entry__sets {
+    font-size: 0.78rem;
+    color: var(--muted);
+    margin-bottom: 0.75rem;
+  }
+  .tune-entry__sets strong { color: var(--text); font-weight: 700; }
+
+  .tune-entry__aliases {
+    font-size: 0.75rem;
+    color: var(--dashed);
+    font-style: italic;
+    margin-bottom: 0.75rem;
+  }
+
+  /* Chart block */
+  .chart {
+    border: 1px dashed var(--dashed);
+    background: var(--chart-bg);
+    padding: 0.75rem 1rem;
+    font-size: 0.82rem;
+    line-height: var(--line-height);
+    overflow-x: auto;
+    white-space: pre;
+  }
+
+  /* ---- Responsive ---- */
+  @media (max-width: 640px) {
+    .page { padding: 1.5rem 1rem 3rem; }
+    .notebook-header__title { font-size: 1.8rem; line-height: 3rem; }
+    .hero__heading { font-size: 1.2rem; }
+    .stats { gap: 1.5rem; }
+    .chart { font-size: 0.72rem; padding: 0.5rem 0.75rem; }
+  }
+</style>
+</head>
+<body>
+<div class="page">
+
+  <a href="design-board.html" class="back-link">← Back to Design Board</a>
+  <div class="design-label">Option F — Music Paper</div>
+
+  <!-- ============================================
+       SECTION 1: HOMEPAGE
+       ============================================ -->
+
+  <header class="notebook-header">
+    <div class="notebook-header__title">SessionBook</div>
+    <div class="notebook-header__subtitle">Chord charts for the Irish trad session</div>
+    <nav class="notebook-header__nav">
+      <a href="#">Tunes</a>
+      <a href="#">Sets</a>
+      <a href="#">Sessions</a>
+      <a href="#">About</a>
+    </nav>
+  </header>
+
+  <section class="hero">
+    <h1 class="hero__heading">Your notebook for the session.</h1>
+    <p class="hero__text">
+      Chord charts, set lists, and tune notes — all in one place.
+      Built for guitarists, bouzouki players, and anyone who backs
+      tunes at the Irish trad session.
+    </p>
+    <p class="hero__text">
+      Every chart is written the way you'd scribble it in a notebook
+      before a session. Simple chords, clear changes, nothing extra.
+    </p>
+  </section>
+
+  <div class="stats">
+    <div class="stat">
+      <div class="stat__number">48</div>
+      <div class="stat__label">Tunes</div>
+    </div>
+    <div class="stat">
+      <div class="stat__number">12</div>
+      <div class="stat__label">Sets</div>
+    </div>
+    <div class="stat">
+      <div class="stat__number">6</div>
+      <div class="stat__label">Sessions</div>
+    </div>
+    <div class="stat">
+      <div class="stat__number">3</div>
+      <div class="stat__label">Modes</div>
+    </div>
+  </div>
+
+  <div class="section-links">
+    <div class="section-links__heading">Browse</div>
+    <ul>
+      <li><a href="#">All tunes, alphabetical</a></li>
+      <li><a href="#">Tunes by type — jigs, reels, hornpipes</a></li>
+      <li><a href="#">Tunes by key and mode</a></li>
+      <li><a href="#">Set lists for upcoming sessions</a></li>
+    </ul>
+  </div>
+
+  <hr class="section-divider">
+
+  <!-- ============================================
+       SECTION 2: TUNE INDEX
+       ============================================ -->
+
+  <section>
+    <h2 class="tune-index__heading">Tune Index</h2>
+    <p class="tune-index__sub">6 tunes — sorted as they'd appear in the notebook</p>
+
+    <!-- Tune 1 -->
+    <article class="tune-entry">
+      <div class="stamp">Jig — Em</div>
+      <h3 class="tune-entry__name">Morrison's Jig</h3>
+      <div class="tune-entry__info">
+        <span>Chart: Standard</span>
+        <span>Mode: Em Dorian</span>
+        <span>Meter: 6/8</span>
+      </div>
+      <div class="tune-entry__sets"><strong>Sets:</strong> Jig Set 1, First Friday December</div>
+      <div class="tune-entry__aliases">aka Morrison's</div>
+      <pre class="chart">| Em / / / | / / D / | Em / / / | C / D / |
+| Em / / / | / / D / | Em / / / | C / D / |
+| Em / / / | / / D / | C  / / / | D / / / |</pre>
+    </article>
+
+    <!-- Tune 2 -->
+    <article class="tune-entry">
+      <div class="stamp">Jig — Em</div>
+      <h3 class="tune-entry__name">The Butterfly</h3>
+      <div class="tune-entry__info">
+        <span>Chart: Standard</span>
+        <span>Mode: Em Dorian</span>
+        <span>Meter: 6/8</span>
+      </div>
+      <div class="tune-entry__sets"><strong>Sets:</strong> Jig Set 1</div>
+      <pre class="chart">|  Em  /  /  |  /  /  D  |  Em  /  /  |  D  /  /  |
+|  Am  /  /  |  /  /  Bm  |  Am  /  /  |  /  /  Bm |
+|  Em  /  /  |  / / / | D  /  /  |  / / / |
+|  C   /  /  |  / / / | Bm /  /  |  / / / |</pre>
+    </article>
+
+    <!-- Tune 3 -->
+    <article class="tune-entry">
+      <div class="stamp">Jig — Em</div>
+      <h3 class="tune-entry__name">Swallowtail Jig</h3>
+      <div class="tune-entry__info">
+        <span>Chart: Standard</span>
+        <span>Mode: Em Dorian</span>
+        <span>Meter: 6/8</span>
+      </div>
+      <div class="tune-entry__sets"><strong>Sets:</strong> Jig Set 1</div>
+      <pre class="chart">| Em /  /  /  |  D  /  /  /  |  Em  /  /  / |  D  /  /  Em |
+| Em /  /  /  |  /  /  /  D  |  Em  /  /  / |  /  D  /  Em  |</pre>
+    </article>
+
+    <!-- Tune 4 -->
+    <article class="tune-entry">
+      <div class="stamp">Jig — G</div>
+      <h3 class="tune-entry__name">Saddle the Pony</h3>
+      <div class="tune-entry__info">
+        <span>Chart: Standard</span>
+        <span>Mode: G Major</span>
+        <span>Meter: 6/8</span>
+      </div>
+      <div class="tune-entry__sets"><strong>Sets:</strong> Jig Set 2</div>
+      <pre class="chart">| G  / Am / | G / D / | G / Am / | C / D G |
+| Em / / / | /  / D / | Em / / / | C / D G |</pre>
+    </article>
+
+    <!-- Tune 5 -->
+    <article class="tune-entry">
+      <div class="stamp">Reel — D</div>
+      <h3 class="tune-entry__name">The Green Mountain</h3>
+      <div class="tune-entry__info">
+        <span>Chart: Standard</span>
+        <span>Mode: D Major</span>
+        <span>Meter: 4/4</span>
+      </div>
+      <div class="tune-entry__sets"><strong>Sets:</strong> Reel Set 1</div>
+      <pre class="chart">| D / / / / | Em / G A | D / / / | Em / A D |
+| D / G / | Em / A  / | D / G / | Em  / A D |</pre>
+    </article>
+
+    <!-- Tune 6 -->
+    <article class="tune-entry">
+      <div class="stamp">Reel — D</div>
+      <h3 class="tune-entry__name">Wind that Shakes the Barley</h3>
+      <div class="tune-entry__info">
+        <span>Chart: Standard</span>
+        <span>Mode: D Major</span>
+        <span>Meter: 4/4</span>
+      </div>
+      <div class="tune-entry__sets"><strong>Sets:</strong> Reel Set 1</div>
+      <pre class="chart">{2x}| D / / / | G / / /  | Bm / / / | A / / / |
+{1x}| D G D / | D G A / | D G D / | G / A / |</pre>
+    </article>
+
+  </section>
+
+  <footer class="page-footer">— p. 1 —</footer>
+
+</div>
+</body>
+</html>

--- a/src/app/gigs/st-paddys-day/page.tsx
+++ b/src/app/gigs/st-paddys-day/page.tsx
@@ -14,60 +14,62 @@ export default async function StPaddysDayGigPage() {
   }
 
   return (
-    <div className="placeholder-page">
+    <div style={{ paddingTop: "2.5rem" }}>
       <p className="eyebrow">{section.status}</p>
-      <h1>{gigSheet.name}</h1>
+      <h1
+        style={{
+          fontSize: "1.35rem",
+          fontWeight: 700,
+          letterSpacing: "-0.015em",
+          marginBottom: "0.25rem",
+        }}
+      >
+        {gigSheet.name}
+      </h1>
       <p className="lead">{gigSheet.summary}</p>
 
-      <section className="callout">
-        <h2>Why this still counts as private content</h2>
+      <div className="callout">
+        <h2>Private content</h2>
         <ul className="checklist">
           <li>
-            The stored gig-sheet record is marked <code>private</code> in the
+            This gig-sheet record is marked <code>private</code> in the
             repository.
           </li>
           <li>
-            Its ordered entries point back to public sets by stable IDs instead
-            of copying tune data into a one-off page.
+            Entries reference public sets by stable IDs instead of copying tune
+            data.
           </li>
-          <li>
-            Auth can enforce access later without replacing the imported Release
-            1 storage contract or the Postgres seed path behind it.
-          </li>
+          <li>Auth enforcement will gate access in a later issue.</li>
         </ul>
-      </section>
+      </div>
 
-      <section className="section-block">
-        <h2>Imported gig-sheet structure</h2>
-        <div className="section-grid">
-          {gigSheet.entries.map((entry) => (
-            <article
-              className="section-card"
-              key={`${gigSheet.id}-${entry.position}`}
-            >
-              <p className="section-card__status">Set slot {entry.position}</p>
-              <h3>{entry.setName}</h3>
-              <p>{entry.setSummary}</p>
-              <p className="section-card__issue">
-                Tunes: {entry.tuneNames.join(" -> ")}
-              </p>
+      <div className="gig-entries">
+        {gigSheet.entries.map((entry) => (
+          <div className="gig-slot" key={`${gigSheet.id}-${entry.position}`}>
+            <div className="gig-slot__header">
+              <span className="gig-slot__pos">Set {entry.position}</span>
+              <span className="gig-slot__name">{entry.setName}</span>
+            </div>
+            <div className="gig-slot__body">
+              <p style={{ marginBottom: "0.25rem" }}>{entry.setSummary}</p>
+              <p className="gig-slot__tunes">{entry.tuneNames.join(" → ")}</p>
               {entry.transitionNotes ? (
-                <p>
-                  <strong>Transition note:</strong> {entry.transitionNotes}
+                <p style={{ marginTop: "0.35rem", fontStyle: "italic" }}>
+                  Note: {entry.transitionNotes}
                 </p>
               ) : null}
-            </article>
-          ))}
-        </div>
-      </section>
+            </div>
+          </div>
+        ))}
+      </div>
 
       <p className="data-note">
-        This route is still ungated until the auth issue lands. The storage
-        contract is complete here; access control is intentionally deferred.
+        This route is ungated until auth enforcement lands. The storage contract
+        is complete; access control is deferred.
       </p>
 
       <p className="back-link">
-        <Link href="/">Back to the catalog overview</Link>
+        <Link href="/">← Back to home</Link>
       </p>
     </div>
   );

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,35 +1,37 @@
+/* ─── Design Tokens ─── */
+
 :root {
   color-scheme: light;
-  --background: #f8f5f1;
-  --surface: #ffffff;
-  --surface-muted: #f2ece4;
-  --text: #1f1b18;
-  --muted: #6f6459;
-  --border: #ded3c5;
-  --accent: #2f5d46;
-  --accent-strong: #214332;
-  --shadow: 0 20px 40px rgba(31, 27, 24, 0.08);
+  --background: #ffffff;
+  --surface: #f9fafb;
+  --text: #111827;
+  --text-secondary: #374151;
+  --muted: #6b7280;
+  --faint: #9ca3af;
+  --border: #e5e7eb;
+  --border-light: #f3f4f6;
+  --mono: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
 }
 
-* {
+/* ─── Reset ─── */
+
+*,
+*::before,
+*::after {
   box-sizing: border-box;
+  margin: 0;
+  padding: 0;
 }
 
-html {
-  font-size: 16px;
-}
+/* ─── Base ─── */
 
 body {
-  margin: 0;
-  background: radial-gradient(
-    circle at top,
-    #fcfbf8 0%,
-    var(--background) 55%,
-    #efe7dd 100%
-  );
+  font-family:
+    -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  background: var(--background);
   color: var(--text);
-  font-family: Georgia, "Times New Roman", serif;
-  min-height: 100vh;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
 }
 
 a {
@@ -37,10 +39,7 @@ a {
   text-decoration: none;
 }
 
-p,
-li {
-  line-height: 1.65;
-}
+/* ─── Site Shell ─── */
 
 .site-shell {
   min-height: 100vh;
@@ -48,189 +47,511 @@ li {
   flex-direction: column;
 }
 
-.site-header,
-.site-footer {
-  padding: 1.5rem;
-}
-
-.site-header__inner,
-.site-main,
-.site-footer {
-  width: min(72rem, calc(100% - 2rem));
-  margin: 0 auto;
+.site-header {
+  border-bottom: 1px solid var(--border-light);
 }
 
 .site-header__inner {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 1rem;
+  max-width: 52rem;
+  margin: 0 auto;
+  padding: 0.875rem 1.5rem;
 }
 
 .site-logo {
-  display: inline-block;
-  font-size: 1.6rem;
+  font-size: 1.05rem;
   font-weight: 700;
-  letter-spacing: 0.02em;
+  letter-spacing: -0.01em;
 }
 
 .site-tagline {
-  margin: 0.35rem 0 0;
-  color: var(--muted);
+  font-size: 0.75rem;
+  color: var(--faint);
+  margin-left: 0.5rem;
 }
 
 .site-nav {
   display: flex;
-  flex-wrap: wrap;
-  gap: 0.85rem;
+  gap: 1.25rem;
   list-style: none;
-  margin: 0;
-  padding: 0;
 }
 
 .site-nav__link {
-  color: var(--accent-strong);
-  font-weight: 600;
+  font-size: 0.8125rem;
+  color: var(--muted);
+  font-weight: 500;
+  transition: color 0.15s;
+}
+
+.site-nav__link:hover {
+  color: var(--text);
 }
 
 .site-main {
   flex: 1;
-  padding-bottom: 4rem;
+  max-width: 52rem;
+  width: 100%;
+  margin: 0 auto;
+  padding: 0 1.5rem 4rem;
 }
 
 .site-footer {
-  color: var(--muted);
-  font-size: 0.95rem;
+  max-width: 52rem;
+  margin: 0 auto;
+  padding: 1.5rem;
+  color: var(--faint);
+  font-size: 0.8125rem;
+  border-top: 1px solid var(--border-light);
 }
 
-.hero,
-.placeholder-page {
-  padding: 2rem 0 0;
-}
+/* ─── Homepage Hero ─── */
 
 .hero {
-  display: grid;
-  gap: 2rem;
+  padding: 3rem 0 0;
+  text-align: center;
 }
 
-.hero__panel,
-.callout,
-.section-card {
-  background: rgba(255, 255, 255, 0.92);
-  border: 1px solid var(--border);
-  border-radius: 1.25rem;
-  box-shadow: var(--shadow);
-}
-
-.hero__panel {
-  padding: 2rem;
-}
-
-.eyebrow,
-.section-card__status {
-  color: var(--accent);
-  font-size: 0.9rem;
+.hero h1 {
+  font-size: 1.75rem;
   font-weight: 700;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-}
-
-.hero h1,
-.placeholder-page h1,
-.not-found h1 {
-  font-size: clamp(2.5rem, 6vw, 4rem);
-  line-height: 1.1;
-  margin: 0.35rem 0 1rem;
-}
-
-.lead {
-  font-size: 1.15rem;
-  color: var(--muted);
-  max-width: 44rem;
+  letter-spacing: -0.02em;
+  margin-bottom: 0.5rem;
 }
 
 .hero__summary {
-  display: grid;
-  gap: 1rem;
   color: var(--muted);
+  font-size: 0.9375rem;
+  max-width: 36rem;
+  margin: 0 auto 1.5rem;
+}
+
+.hero__actions {
+  display: flex;
+  gap: 0.625rem;
+  justify-content: center;
+  flex-wrap: wrap;
+  margin-bottom: 1.75rem;
+}
+
+/* ─── Buttons ─── */
+
+.btn {
+  display: inline-block;
+  padding: 0.5rem 1.125rem;
+  font-size: 0.8125rem;
+  font-weight: 600;
+  border-radius: 0.375rem;
+  text-decoration: none;
+  border: none;
+  cursor: pointer;
+  transition: background 0.15s;
+}
+
+.btn-primary {
+  background: var(--text);
+  color: #fff;
+}
+
+.btn-primary:hover {
+  background: var(--text-secondary);
+}
+
+.btn-secondary {
+  background: var(--border-light);
+  color: var(--text-secondary);
+}
+
+.btn-secondary:hover {
+  background: var(--border);
+}
+
+/* ─── Stats Bar ─── */
+
+.stats-bar {
+  display: flex;
+  justify-content: center;
+  gap: 2rem;
+  padding: 0.75rem 0 1.75rem;
+  font-size: 0.8125rem;
+  color: var(--faint);
+}
+
+.stats-bar strong {
+  color: var(--text);
+  font-weight: 600;
+}
+
+/* ─── Quick Links ─── */
+
+.quick-links {
+  display: flex;
+  justify-content: center;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+  padding-bottom: 2.5rem;
+  border-bottom: 1px solid var(--border-light);
+}
+
+.quick-link {
+  font-size: 0.8125rem;
+  color: var(--muted);
+  padding: 0.375rem 0.875rem;
+  border: 1px solid var(--border);
+  border-radius: 0.375rem;
+  transition: all 0.15s;
+}
+
+.quick-link:hover {
+  border-color: #d1d5db;
+  color: var(--text);
+  background: var(--surface);
+}
+
+/* ─── Section Cards ─── */
+
+.section-block {
+  margin-top: 2rem;
+}
+
+.section-block h2 {
+  font-size: 1rem;
+  font-weight: 700;
+  margin-bottom: 0.75rem;
 }
 
 .section-grid {
   display: grid;
-  gap: 1rem;
-  grid-template-columns: repeat(auto-fit, minmax(16rem, 1fr));
+  gap: 0.75rem;
+  grid-template-columns: repeat(auto-fit, minmax(14rem, 1fr));
 }
 
 .section-card {
-  padding: 1.5rem;
+  padding: 1rem;
+  border: 1px solid var(--border);
+  border-radius: 0.5rem;
+  transition: background 0.15s;
+}
+
+.section-card:hover {
+  background: var(--surface);
+}
+
+.section-card__status {
+  font-size: 0.6875rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--faint);
 }
 
 .section-card h3 {
-  margin: 0.25rem 0 0.75rem;
-  font-size: 1.35rem;
+  font-size: 0.9375rem;
+  font-weight: 600;
+  margin: 0.2rem 0 0.35rem;
+}
+
+.section-card p {
+  font-size: 0.8125rem;
+  color: var(--muted);
+  line-height: 1.5;
 }
 
 .section-card__issue {
-  margin-bottom: 0;
-  color: var(--muted);
+  font-size: 0.75rem;
+  color: var(--faint);
   font-style: italic;
+  margin-top: 0.5rem;
+  margin-bottom: 0;
 }
 
 .section-card__metric {
-  font-size: clamp(2rem, 4vw, 3rem);
+  font-size: 2rem;
   font-weight: 700;
   line-height: 1;
-  margin: 0.5rem 0 0.75rem;
+  margin: 0.35rem 0 0.5rem;
 }
 
-.section-block {
+/* ─── Type Badges ─── */
+
+.type-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.5rem;
+  height: 2.5rem;
+  border-radius: 0.375rem;
+  font-size: 0.625rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+  flex-shrink: 0;
+  user-select: none;
+}
+
+.type-badge--jig {
+  background: #fef3c7;
+  color: #92400e;
+}
+
+.type-badge--reel {
+  background: #dbeafe;
+  color: #1e40af;
+}
+
+.type-badge--hornpipe {
+  background: #fce7f3;
+  color: #9d174d;
+}
+
+.type-badge--polka {
+  background: #d1fae5;
+  color: #065f46;
+}
+
+/* ─── Tune Index ─── */
+
+.index-header {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin-bottom: 0.25rem;
+}
+
+.index-header h1 {
+  font-size: 1.35rem;
+  font-weight: 700;
+  letter-spacing: -0.015em;
+}
+
+.index-subtitle {
+  font-size: 0.8125rem;
+  color: var(--muted);
+  margin-bottom: 1.25rem;
+}
+
+.tune-list {
+  border-top: 1px solid var(--border);
+}
+
+.tune-row {
   display: grid;
-  gap: 1rem;
+  grid-template-columns: 2.5rem 1fr auto;
+  gap: 0.875rem;
+  align-items: center;
+  padding: 0.625rem 0;
+  border-bottom: 1px solid var(--border-light);
+  cursor: pointer;
+  transition: background 0.1s;
 }
 
-.section-block h2,
-.callout h2 {
-  margin: 0;
-  font-size: 1.4rem;
+.tune-row:hover {
+  background: var(--surface);
+  margin: 0 -0.75rem;
+  padding-left: 0.75rem;
+  padding-right: 0.75rem;
 }
+
+.tune-name {
+  font-size: 0.9375rem;
+  font-weight: 600;
+  color: var(--text);
+  line-height: 1.3;
+}
+
+.tune-sub {
+  font-size: 0.75rem;
+  color: var(--faint);
+  line-height: 1.35;
+}
+
+.tune-meta {
+  text-align: right;
+  flex-shrink: 0;
+  white-space: nowrap;
+}
+
+.tune-meta__key {
+  font-size: 0.8125rem;
+  font-weight: 500;
+  color: var(--text-secondary);
+}
+
+.tune-meta__meter {
+  font-size: 0.6875rem;
+  color: var(--faint);
+}
+
+/* ─── Expandable Chart ─── */
+
+.tune-chart {
+  display: none;
+  padding: 0.875rem 1rem;
+  margin-bottom: 0.125rem;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 0.375rem;
+  font-family: var(--mono);
+  font-size: 0.75rem;
+  line-height: 1.7;
+  color: var(--text-secondary);
+  white-space: pre;
+  overflow-x: auto;
+}
+
+.tune-chart[data-expanded="true"] {
+  display: block;
+}
+
+.tune-chart__label {
+  font-family:
+    -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  font-size: 0.6875rem;
+  font-weight: 600;
+  color: var(--faint);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  display: block;
+  margin-bottom: 0.375rem;
+}
+
+/* ─── Set Index ─── */
+
+.set-row {
+  border: 1px solid var(--border);
+  border-radius: 0.5rem;
+  overflow: hidden;
+  margin-bottom: 0.75rem;
+}
+
+.set-row__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.75rem 1rem;
+  background: var(--surface);
+  cursor: pointer;
+  transition: background 0.1s;
+}
+
+.set-row__header:hover {
+  background: var(--border-light);
+}
+
+.set-row__name {
+  font-size: 0.9375rem;
+  font-weight: 600;
+}
+
+.set-row__count {
+  font-size: 0.75rem;
+  color: var(--faint);
+}
+
+.set-row__entries {
+  list-style: none;
+}
+
+.set-entry {
+  display: grid;
+  grid-template-columns: 1.75rem 2rem 1fr auto;
+  gap: 0.5rem;
+  align-items: center;
+  padding: 0.5rem 1rem;
+  border-top: 1px solid var(--border-light);
+  font-size: 0.8125rem;
+}
+
+.set-entry__pos {
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: var(--faint);
+  text-align: center;
+}
+
+.set-entry__badge {
+  width: 2rem;
+  height: 1.5rem;
+  border-radius: 0.25rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.5rem;
+  font-weight: 700;
+  text-transform: uppercase;
+}
+
+.set-entry__name {
+  font-weight: 500;
+  color: var(--text);
+}
+
+.set-entry__key {
+  font-size: 0.75rem;
+  color: var(--faint);
+  text-align: right;
+}
+
+/* ─── Callout ─── */
 
 .callout {
-  padding: 1.5rem;
+  padding: 1rem 1.25rem;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 0.5rem;
   margin-top: 1.5rem;
 }
 
+.callout h2 {
+  font-size: 0.9375rem;
+  font-weight: 700;
+  margin-bottom: 0.5rem;
+}
+
 .checklist {
-  margin: 1rem 0 0;
+  margin: 0;
   padding-left: 1.15rem;
+  font-size: 0.8125rem;
+  color: var(--muted);
+  line-height: 1.65;
 }
 
-.meta-list,
-.entry-list {
-  margin: 1rem 0 0;
-  padding-left: 1.15rem;
+/* ─── Placeholder Page ─── */
+
+.placeholder-page {
+  padding: 2.5rem 0 0;
 }
 
-.meta-list {
-  display: grid;
-  gap: 0.35rem;
+.placeholder-page h1 {
+  font-size: 1.35rem;
+  font-weight: 700;
+  letter-spacing: -0.015em;
+  margin-bottom: 0.25rem;
 }
 
-.chart-preview {
-  margin: 1rem 0 0;
-  padding: 1rem;
-  background: var(--surface-muted);
-  border: 1px solid var(--border);
-  border-radius: 1rem;
-  font-family:
-    ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono",
-    monospace;
-  font-size: 0.92rem;
-  line-height: 1.55;
-  white-space: pre-wrap;
+.eyebrow {
+  font-size: 0.6875rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--faint);
+  margin-bottom: 0.25rem;
 }
+
+.lead {
+  font-size: 0.9375rem;
+  color: var(--muted);
+  max-width: 40rem;
+}
+
+/* ─── Misc ─── */
 
 .data-note {
   color: var(--muted);
+  font-size: 0.8125rem;
   margin-top: 1.5rem;
 }
 
@@ -239,47 +560,113 @@ li {
 }
 
 .back-link a {
-  color: var(--accent-strong);
-  font-weight: 700;
+  font-size: 0.8125rem;
+  font-weight: 600;
+  color: var(--muted);
+  transition: color 0.15s;
 }
 
-.action-row {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.75rem;
-  margin-top: 1.5rem;
-}
-
-.action-button,
-.action-link {
-  appearance: none;
-  border-radius: 999px;
-  font: inherit;
-  font-weight: 700;
-  padding: 0.75rem 1.1rem;
-}
-
-.action-button {
-  background: var(--accent);
-  border: 0;
-  color: #fff;
-  cursor: pointer;
-}
-
-.action-link {
-  border: 1px solid var(--border);
-  color: var(--accent-strong);
-  display: inline-flex;
-  align-items: center;
+.back-link a:hover {
+  color: var(--text);
 }
 
 .not-found {
   padding: 3rem 0 0;
+  text-align: center;
 }
 
-@media (max-width: 48rem) {
+.not-found h1 {
+  font-size: 1.35rem;
+  font-weight: 700;
+  margin-bottom: 0.35rem;
+}
+
+/* ─── Gig Page ─── */
+
+.gig-entries {
+  margin-top: 1.5rem;
+}
+
+.gig-slot {
+  border: 1px solid var(--border);
+  border-radius: 0.5rem;
+  overflow: hidden;
+  margin-bottom: 0.75rem;
+}
+
+.gig-slot__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.75rem 1rem;
+  background: var(--surface);
+}
+
+.gig-slot__pos {
+  font-size: 0.6875rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--faint);
+}
+
+.gig-slot__name {
+  font-size: 0.9375rem;
+  font-weight: 600;
+}
+
+.gig-slot__body {
+  padding: 0.75rem 1rem;
+  font-size: 0.8125rem;
+  color: var(--muted);
+  line-height: 1.6;
+}
+
+.gig-slot__tunes {
+  font-size: 0.8125rem;
+  color: var(--text-secondary);
+  font-weight: 500;
+}
+
+/* ─── Responsive ─── */
+
+@media (max-width: 640px) {
   .site-header__inner {
-    align-items: flex-start;
-    flex-direction: column;
+    padding: 0.75rem 1rem;
+  }
+
+  .site-tagline {
+    display: none;
+  }
+
+  .site-main {
+    padding: 0 1rem 3rem;
+  }
+
+  .hero h1 {
+    font-size: 1.375rem;
+  }
+
+  .stats-bar {
+    gap: 1rem;
+    font-size: 0.75rem;
+  }
+
+  .tune-row {
+    gap: 0.625rem;
+  }
+
+  .tune-meta__key {
+    font-size: 0.75rem;
+  }
+
+  .section-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .set-entry {
+    grid-template-columns: 1.5rem 1.75rem 1fr auto;
+    gap: 0.35rem;
+    font-size: 0.75rem;
   }
 }

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -5,12 +5,11 @@ export default function NotFound() {
     <div className="not-found">
       <p className="eyebrow">Not found</p>
       <h1>There isn&apos;t anything here yet.</h1>
-      <p className="lead">
-        This bootstrap only sets up the Release 1 shell, so some routes will
-        stay intentionally empty until their feature issues land.
+      <p className="lead" style={{ margin: "0 auto" }}>
+        Some routes are still in progress and will land in future issues.
       </p>
       <p className="back-link">
-        <Link href="/">Return to SessionBook</Link>
+        <Link href="/">← Back to SessionBook</Link>
       </p>
     </div>
   );

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,3 +1,5 @@
+import Link from "next/link";
+
 import { SectionCard } from "@/components/section-card";
 import { loadRelease1Repository } from "@/lib/release-1/load-repository";
 import { ownerSections, publicSections } from "@/lib/site-navigation";
@@ -5,99 +7,54 @@ import { ownerSections, publicSections } from "@/lib/site-navigation";
 export const dynamic = "force-dynamic";
 
 export default async function HomePage() {
-  const { repository, source } = await loadRelease1Repository();
+  const { repository } = await loadRelease1Repository();
   const summary = repository.getCatalogSummary();
-  const storageSourceLabel =
-    source === "database"
-      ? "Neon/Postgres via the live runtime"
-      : "the checked-in imported catalog";
-  const metricCards = [
-    {
-      label: "Public tunes",
-      value: summary.publicTuneCount,
-      description: `${summary.aliasCount} aliases and ${summary.chartCount} validated charts sit behind the tune index.`,
-    },
-    {
-      label: "Public sets",
-      value: summary.publicSetCount,
-      description:
-        "Each set stores ordered tune-to-chart references instead of flattening the catalog.",
-    },
-    {
-      label: "Private gig sheets",
-      value: summary.privateGigSheetCount,
-      description:
-        "Private gig data stays distinct from the public catalog even before auth enforcement lands.",
-    },
-  ];
 
   return (
     <div className="hero">
-      <section className="hero__panel">
-        <p className="eyebrow">Release 1 public catalog</p>
-        <h1>
-          SessionBook is now a public browseable catalog for Irish trad chord
-          charts.
-        </h1>
-        <div className="hero__summary">
-          <p>
-            Anonymous visitors can now understand the site from the homepage and
-            browse imported public tunes and sets through the shared app shell.
-            The public catalog is backed by the same Release 1 repository that
-            assembles tunes, aliases, charts, sets, and private gig-sheet data.
-          </p>
-          <p>
-            When <code>DATABASE_URL</code> is configured, the live runtime reads
-            directly from Neon/Postgres. Local work can still browse the same
-            catalog from the checked-in import when no database is configured.
-          </p>
-        </div>
-      </section>
+      <h1>Chord charts for the session</h1>
+      <div className="hero__summary">
+        <p>
+          Quick-reference chord progressions for Irish traditional tunes. Built
+          for guitarists, bouzouki players, and anyone comping at the session.
+        </p>
+      </div>
+
+      <div className="hero__actions">
+        <Link className="btn btn-primary" href="/tunes">
+          Browse Tunes
+        </Link>
+        <Link className="btn btn-secondary" href="/sets">
+          View Sets
+        </Link>
+      </div>
+
+      <div className="stats-bar">
+        <span>
+          <strong>{summary.publicTuneCount}</strong> tunes
+        </span>
+        <span>
+          <strong>{summary.publicSetCount}</strong> sets
+        </span>
+        <span>
+          <strong>{summary.chartCount}</strong> charts
+        </span>
+      </div>
+
+      <div className="quick-links">
+        <Link className="quick-link" href="/tunes">
+          All Tunes
+        </Link>
+        <Link className="quick-link" href="/sets">
+          Sets
+        </Link>
+        <Link className="quick-link" href="/search">
+          Search
+        </Link>
+      </div>
 
       <section className="section-block">
-        <h2>What the imported catalog proves</h2>
-        <div className="section-grid">
-          {metricCards.map((card) => (
-            <article className="section-card" key={card.label}>
-              <p className="section-card__status">{card.label}</p>
-              <p className="section-card__metric">{card.value}</p>
-              <p>{card.description}</p>
-            </article>
-          ))}
-        </div>
-      </section>
-
-      <section className="callout">
-        <h2>How this catalog is loaded</h2>
-        <ul className="checklist">
-          <li>Current response source: {storageSourceLabel}.</li>
-          <li>
-            The store is validated with Zod before the repository exposes public
-            catalog views.
-          </li>
-          <li>
-            <code>npm run db:setup</code> creates the Release 1 schema and seeds
-            it from the checked-in imported store when a Postgres connection is
-            available.
-          </li>
-          <li>
-            Local development can still browse the catalog without Postgres, but
-            configured database environments are expected to load the imported
-            Release 1 store directly from Postgres.
-          </li>
-          <li>
-            Charts stay separate from tunes even though the Release 1 seed data
-            uses one chart per tune.
-          </li>
-          <li>
-            Gig sheets remain explicitly private records so auth can layer on
-            later.
-          </li>
-        </ul>
-      </section>
-
-      <section className="section-block">
-        <h2>Public catalog surfaces</h2>
+        <h2>Public catalog</h2>
         <div className="section-grid">
           {publicSections.map((section) => (
             <SectionCard key={section.href} section={section} />
@@ -106,7 +63,7 @@ export default async function HomePage() {
       </section>
 
       <section className="section-block">
-        <h2>Owner-only path</h2>
+        <h2>Owner access</h2>
         <div className="section-grid">
           {ownerSections.map((section) => (
             <SectionCard key={section.href} section={section} />

--- a/src/app/sets/page.tsx
+++ b/src/app/sets/page.tsx
@@ -1,81 +1,64 @@
 import Link from "next/link";
 
 import { loadRelease1Repository } from "@/lib/release-1/load-repository";
-import { getSectionByPath } from "@/lib/site-navigation";
 
 export const dynamic = "force-dynamic";
 
 export default async function SetsPage() {
-  const section = getSectionByPath("/sets");
-  const { repository, source } = await loadRelease1Repository();
+  const { repository } = await loadRelease1Repository();
   const sets = repository.listPublicSets();
-  const storageSourceLabel =
-    source === "database"
-      ? "Neon/Postgres via the live runtime"
-      : "the checked-in imported catalog";
 
   return (
-    <div className="placeholder-page">
-      <p className="eyebrow">{section.status}</p>
-      <h1>{section.label}</h1>
-      <p className="lead">{section.summary}</p>
+    <div style={{ paddingTop: "2.5rem" }}>
+      <div className="index-header">
+        <h1>Sets</h1>
+      </div>
+      <p className="index-subtitle">
+        {sets.length} sets in the public catalog. Each set is an ordered group
+        of tunes.
+      </p>
 
-      <section className="callout">
-        <h2>What this set index surfaces</h2>
-        <ul className="checklist">
-          <li>Current response source: {storageSourceLabel}.</li>
-          <li>
-            Sets load from the imported Release 1 source groups instead of
-            placeholder route content.
-          </li>
-          <li>
-            Each set entry preserves tune order while pointing at explicit chart
-            IDs.
-          </li>
-          <li>
-            The public set catalog stays separate from the private gig-sheet
-            layer that reuses it, whether the repository source is Postgres or
-            the checked-in imported catalog.
-          </li>
-        </ul>
-      </section>
-
-      <section className="section-block">
-        <h2>Imported set index</h2>
-        <div className="section-grid">
-          {sets.length === 0 ? (
-            <article className="section-card">
-              <p className="section-card__status">No public sets</p>
-              <h3>The imported catalog is empty in this environment.</h3>
-              <p>
-                The public set index is ready, but there are no imported public
-                sets available to display right now.
-              </p>
-            </article>
-          ) : (
-            sets.map((setRecord) => (
-              <article className="section-card" key={setRecord.id}>
-                <p className="section-card__status">
-                  {setRecord.entries.length} tune set
-                </p>
-                <h3>{setRecord.name}</h3>
-                <p>{setRecord.summary}</p>
-                <ol className="entry-list">
-                  {setRecord.entries.map((entry) => (
-                    <li key={`${setRecord.id}-${entry.position}`}>
-                      <strong>{entry.tuneName}</strong> - {entry.chartTitle} in{" "}
-                      {entry.key} {entry.mode} ({entry.meter})
-                    </li>
-                  ))}
-                </ol>
-              </article>
-            ))
-          )}
+      {sets.length === 0 ? (
+        <div className="callout">
+          <h2>No public sets</h2>
+          <p style={{ fontSize: "0.8125rem", color: "var(--muted)" }}>
+            The imported catalog is empty in this environment.
+          </p>
         </div>
-      </section>
+      ) : (
+        <div>
+          {sets.map((setRecord) => (
+            <div className="set-row" key={setRecord.id}>
+              <div className="set-row__header">
+                <span className="set-row__name">{setRecord.name}</span>
+                <span className="set-row__count">
+                  {setRecord.entries.length} tunes
+                </span>
+              </div>
+              <ul className="set-row__entries">
+                {setRecord.entries.map((entry) => (
+                  <li
+                    className="set-entry"
+                    key={`${setRecord.id}-${entry.position}`}
+                  >
+                    <span className="set-entry__pos">{entry.position}</span>
+                    <span className="set-entry__badge type-badge--jig">
+                      {/* Tune type not available on set entries; omit text */}
+                    </span>
+                    <span className="set-entry__name">{entry.tuneName}</span>
+                    <span className="set-entry__key">
+                      {entry.key} {entry.mode} · {entry.meter}
+                    </span>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          ))}
+        </div>
+      )}
 
       <p className="back-link">
-        <Link href="/">Back to the catalog overview</Link>
+        <Link href="/">← Back to home</Link>
       </p>
     </div>
   );

--- a/src/app/tunes/page.tsx
+++ b/src/app/tunes/page.tsx
@@ -1,85 +1,37 @@
 import Link from "next/link";
 
+import { TuneList } from "@/components/tune-list";
 import { loadRelease1Repository } from "@/lib/release-1/load-repository";
-import { getSectionByPath } from "@/lib/site-navigation";
 
 export const dynamic = "force-dynamic";
 
 export default async function TunesPage() {
-  const section = getSectionByPath("/tunes");
-  const { repository, source } = await loadRelease1Repository();
+  const { repository } = await loadRelease1Repository();
   const tunes = repository.listPublicTunes();
-  const storageSourceLabel =
-    source === "database"
-      ? "Neon/Postgres via the live runtime"
-      : "the checked-in imported catalog";
 
   return (
-    <div className="placeholder-page">
-      <p className="eyebrow">{section.status}</p>
-      <h1>{section.label}</h1>
-      <p className="lead">{section.summary}</p>
+    <div style={{ paddingTop: "2.5rem" }}>
+      <div className="index-header">
+        <h1>Tunes</h1>
+      </div>
+      <p className="index-subtitle">
+        {tunes.length} tunes in the public catalog. Click a row to view its
+        chord chart.
+      </p>
 
-      <section className="callout">
-        <h2>What this tune index surfaces</h2>
-        <ul className="checklist">
-          <li>Current response source: {storageSourceLabel}.</li>
-          <li>
-            Each public tune loads through the Release 1 repository instead of a
-            placeholder route shell.
-          </li>
-          <li>
-            Aliases stay separate from tune records but resolve back into the
-            visible tune view.
-          </li>
-          <li>
-            The runtime uses the same tune view model whether local development
-            falls back to fixtures or deployed environments read from Postgres.
-          </li>
-        </ul>
-      </section>
-
-      <section className="section-block">
-        <h2>Imported tune index</h2>
-        <div className="section-grid">
-          {tunes.length === 0 ? (
-            <article className="section-card">
-              <p className="section-card__status">No public tunes</p>
-              <h3>The imported catalog is empty in this environment.</h3>
-              <p>
-                The public tune index is in place, but there are no imported
-                tunes available to display right now.
-              </p>
-            </article>
-          ) : (
-            tunes.map((tune) => (
-              <article className="section-card" key={tune.id}>
-                <p className="section-card__status">{tune.tuneType}</p>
-                <h3>{tune.name}</h3>
-                <p>{tune.summary}</p>
-                <ul className="meta-list">
-                  <li>
-                    <strong>Aliases:</strong> {tune.aliases.join(", ")}
-                  </li>
-                  <li>
-                    <strong>Chart:</strong> {tune.chart.title} in{" "}
-                    {tune.chart.key} {tune.chart.mode} ({tune.chart.meter})
-                  </li>
-                  <li>
-                    <strong>Used in sets:</strong> {tune.setNames.join(", ")}
-                  </li>
-                </ul>
-                <pre className="chart-preview">
-                  {tune.chart.contentMarkdown}
-                </pre>
-              </article>
-            ))
-          )}
+      {tunes.length === 0 ? (
+        <div className="callout">
+          <h2>No public tunes</h2>
+          <p style={{ fontSize: "0.8125rem", color: "var(--muted)" }}>
+            The imported catalog is empty in this environment.
+          </p>
         </div>
-      </section>
+      ) : (
+        <TuneList tunes={tunes} />
+      )}
 
       <p className="back-link">
-        <Link href="/">Back to the catalog overview</Link>
+        <Link href="/">← Back to home</Link>
       </p>
     </div>
   );

--- a/src/components/placeholder-page.tsx
+++ b/src/components/placeholder-page.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import Link from "next/link";
 
 import type { SiteSection } from "@/lib/site-navigation";
@@ -14,25 +16,25 @@ export function PlaceholderPage({ section, bullets }: PlaceholderPageProps) {
       <h1>{section.label}</h1>
       <p className="lead">{section.summary}</p>
 
-      <section className="callout">
-        <h2>What this scaffold gives us now</h2>
+      <div className="callout">
+        <h2>What this gives us now</h2>
         <ul className="checklist">
           {bullets.map((bullet) => (
             <li key={bullet}>{bullet}</li>
           ))}
         </ul>
-      </section>
+      </div>
 
-      <section className="callout">
+      <div className="callout">
         <h2>Next planned issue</h2>
-        <p>
+        <p style={{ fontSize: "0.8125rem", color: "var(--muted)" }}>
           This route is reserved for future implementation in issue{" "}
           {section.nextIssue}.
         </p>
-      </section>
+      </div>
 
       <p className="back-link">
-        <Link href="/">Back to the bootstrap overview</Link>
+        <Link href="/">← Back to home</Link>
       </p>
     </div>
   );

--- a/src/components/site-shell.tsx
+++ b/src/components/site-shell.tsx
@@ -16,11 +16,11 @@ export function SiteShell({ children }: SiteShellProps) {
     <div className="site-shell">
       <header className="site-header">
         <div className="site-header__inner">
-          <div>
+          <div style={{ display: "flex", alignItems: "baseline" }}>
             <Link className="site-logo" href="/">
               SessionBook
             </Link>
-            <p className="site-tagline">A home for Irish trad chord charts.</p>
+            <span className="site-tagline">Irish trad chord charts</span>
           </div>
 
           <nav aria-label="Primary">
@@ -40,11 +40,7 @@ export function SiteShell({ children }: SiteShellProps) {
       <main className="site-main">{children}</main>
 
       <footer className="site-footer">
-        <p>
-          Release 1 public browsing now lives on the app runtime. Tune detail
-          pages, search, auth enforcement, and private gig access still land in
-          later issues.
-        </p>
+        <p>SessionBook · Release 1 public catalog</p>
       </footer>
     </div>
   );

--- a/src/components/tune-list.tsx
+++ b/src/components/tune-list.tsx
@@ -1,0 +1,89 @@
+"use client";
+
+import { useState } from "react";
+
+type TuneView = {
+  id: string;
+  slug: string;
+  name: string;
+  tuneType: string;
+  summary: string;
+  aliases: string[];
+  chart: {
+    title: string;
+    key: string;
+    mode: string;
+    meter: string;
+    contentMarkdown: string;
+  };
+  setNames: string[];
+};
+
+type TuneListProps = {
+  tunes: TuneView[];
+};
+
+function tuneTypeBadgeClass(tuneType: string): string {
+  const normalized = tuneType.toLowerCase();
+  if (normalized === "jig") return "type-badge type-badge--jig";
+  if (normalized === "reel") return "type-badge type-badge--reel";
+  if (normalized === "hornpipe") return "type-badge type-badge--hornpipe";
+  if (normalized === "polka") return "type-badge type-badge--polka";
+  return "type-badge type-badge--jig";
+}
+
+export function TuneList({ tunes }: TuneListProps) {
+  const [expanded, setExpanded] = useState<Set<string>>(new Set());
+
+  function toggle(id: string) {
+    setExpanded((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) {
+        next.delete(id);
+      } else {
+        next.add(id);
+      }
+      return next;
+    });
+  }
+
+  return (
+    <div className="tune-list">
+      {tunes.map((tune) => (
+        <div key={tune.id}>
+          <div className="tune-row" onClick={() => toggle(tune.id)}>
+            <div className={tuneTypeBadgeClass(tune.tuneType)}>
+              {tune.tuneType.slice(0, 4)}
+            </div>
+            <div>
+              <div className="tune-name">{tune.name}</div>
+              <div className="tune-sub">
+                {[
+                  tune.aliases.length > 0 ? tune.aliases.join(", ") : null,
+                  tune.setNames.length > 0
+                    ? `Sets: ${tune.setNames.join(", ")}`
+                    : null,
+                ]
+                  .filter(Boolean)
+                  .join(" · ")}
+              </div>
+            </div>
+            <div className="tune-meta">
+              <div className="tune-meta__key">
+                {tune.chart.key} {tune.chart.mode}
+              </div>
+              <div className="tune-meta__meter">{tune.chart.meter}</div>
+            </div>
+          </div>
+          <div
+            className="tune-chart"
+            data-expanded={expanded.has(tune.id) ? "true" : undefined}
+          >
+            <span className="tune-chart__label">Chord Chart</span>
+            {tune.chart.contentMarkdown}
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}


### PR DESCRIPTION
## What

Replaces the warm-serif/parchment design with a clean, compact index layout. This emerged from a design board exploration of 6 directions — the **Compact Index** style was chosen for its scanability and density.

### Design direction
- **Font**: System sans-serif (no more Georgia serif)
- **Palette**: Cool grays with white background
- **Tune type badges**: Color-coded (jig=amber, reel=blue, hornpipe=pink, polka=green)
- **Tune list**: Compact scrollable rows with click-to-expand chord charts
- **Sets**: Card-based groups with ordered tune entries

### Changes
- `globals.css`: Complete rewrite with new design system tokens
- `page.tsx` (homepage): Centered hero, stats bar, quick-link pills, clean section cards
- `tunes/page.tsx`: Compact index list with expandable accordion charts
- `sets/page.tsx`: Card-style set groups with tune entries
- `gigs/st-paddys-day/page.tsx`: Slot-based gig layout
- `site-shell.tsx`: Streamlined header with inline tagline, minimal footer
- `placeholder-page.tsx`: Updated for new design language
- `not-found.tsx`: Clean compact styling
- New `tune-list.tsx`: Client component for expandable chart accordion
- `.prettierignore`: Excludes design board HTML mockups

### Design board
The design board mockups (`design-*.html`) are included in this branch for reference. They show all 6 directions explored, plus a tune detail page mockup for the chosen compact style.

### Verification
- ✅ Lint passes
- ✅ Typecheck passes
- ✅ Build passes
- ✅ All tests pass (27/27)