### PR TITLE
UI polish: mobile-friendly chord charts + session work update

### DIFF
--- a/Sessions/commodore-barry-club-first-friday-session-2026-04-03_session_work.md
+++ b/Sessions/commodore-barry-club-first-friday-session-2026-04-03_session_work.md
@@ -293,20 +293,13 @@
 = part: A
 
 ```
-| D / G D | G / A / |
-| D / G D | G A D / |
+| D / / / | G  / Em A | D / /  / | G A .D / |
 ```
 
 = part: B
 ```
-| D / / / | G / A / |
-| D / / / | G / A D |
-```
-
-= alt: B
-```
-| D  / / / | G / A / |
-| Bm / / A | G / A D |
+| D / Bm / | G / A / |
+| D / Bm / | G / A <D |
 ```
 
 ## O'Carolan

--- a/Sessions/commodore-barry-club-first-friday-session-2026-04-03_session_work.md
+++ b/Sessions/commodore-barry-club-first-friday-session-2026-04-03_session_work.md
@@ -10,8 +10,6 @@
 
 **The Lisnagun** (G)
 
-=> https://thesession.org/tunes/3842#setting46053
-
 = part: A
 ```
 | G / D C | / / D / | G / D C | / / D G |
@@ -106,9 +104,6 @@
 
 **Glen of Aherlow (Lafferty's)** (Edor)
 
-=> https://thesession.org/tunes/496#setting45009
-> The Session lists `Lafferty's` as an alias for this reel.
-
 = part: A
 ```
 | Em A D / | Em / Bm / | Em A D / |Em / Bm Em |
@@ -182,10 +177,6 @@
 
 **Miss McLeod's** (G)
 
-=> https://thesession.org/tunes/75#setting31921
-> The Session comments there also call G the common Irish-session key for this
-> reel.
-
 = part: A
 
 ```
@@ -227,10 +218,10 @@
 = part: A
 
 ```
-| Em / / | D / / | Em / / | Bm / Em |
+| Em / / | Bm / / | Em / / | Bm / Em |
 ```
 
-= alt: A | Sub C
+= alt: A | Sub D Sub C
 
 ```
 | Em / / | D / / | C / / | Bm / Em |
@@ -239,7 +230,7 @@
 = part: B
 ```
 | C / / | Bm / / | Em / / | G / / |
-| C / / | Bm / / | Am  / / | C / Em   |
+| C / / | Bm / / | Am  / / | C / Em |
 ```
 
 ## Hornpipes
@@ -247,8 +238,6 @@
 ---
 
 **The Good-Natured Man** (G)
-
-=> https://thesession.org/tunes/312#setting45001
 
 = part: A
 
@@ -265,8 +254,6 @@
 ```
 
 **The Fairies' Hornpipe** (G)
-
-=> Sessions/chyunes_mbys.md
 
 = part: A
 

--- a/content/tunes/dark-girl-dressed-in-blue.md
+++ b/content/tunes/dark-girl-dressed-in-blue.md
@@ -14,22 +14,14 @@ visibility: public
 = part: A
 
 ```
-| D / G D | G / A / |
-| D / G D | G A D / |
+| D / / / | G  / Em A | D / /  / | G A .D / |
 ```
 
 = part: B
 
 ```
-| D / / / | G / A / |
-| D / / / | G / A D |
-```
-
-= alt: B
-
-```
-| D  / / / | G / A / |
-| Bm / / A | G / A D |
+| D / Bm / | G / A / |
+| D / Bm / | G / A <D |
 ```
 
 ## Notes

--- a/content/tunes/fig-for-a-kiss.md
+++ b/content/tunes/fig-for-a-kiss.md
@@ -14,10 +14,10 @@ visibility: public
 = part: A
 
 ```
-| Em / / | D / / | Em / / | Bm / Em |
+| Em / / | Bm / / | Em / / | Bm / Em |
 ```
 
-= alt: A | Sub C
+= alt: A | Sub D Sub C
 
 ```
 | Em / / | D / / | C / / | Bm / Em |
@@ -27,7 +27,7 @@ visibility: public
 
 ```
 | C / / | Bm / / | Em / / | G / / |
-| C / / | Bm / / | Am  / / | C / Em   |
+| C / / | Bm / / | Am  / / | C / Em |
 ```
 
 ## Notes

--- a/content/tunes/glen-of-aherlow.md
+++ b/content/tunes/glen-of-aherlow.md
@@ -26,9 +26,3 @@ visibility: public
 ```
 
 ## Notes
-
-The Session lists `Lafferty's` as an alias for this reel.
-
-## Links
-
-https://thesession.org/tunes/496#setting45009

--- a/content/tunes/miss-mcleods.md
+++ b/content/tunes/miss-mcleods.md
@@ -24,10 +24,3 @@ visibility: public
 ```
 
 ## Notes
-
-The Session comments there also call G the common Irish-session key for this
-reel.
-
-## Links
-
-https://thesession.org/tunes/75#setting31921

--- a/content/tunes/the-fairies-hornpipe.md
+++ b/content/tunes/the-fairies-hornpipe.md
@@ -26,7 +26,3 @@ visibility: public
 ```
 
 ## Notes
-
-## Links
-
-Sessions/chyunes_mbys.md

--- a/content/tunes/the-good-natured-man.md
+++ b/content/tunes/the-good-natured-man.md
@@ -26,7 +26,3 @@ visibility: public
 ```
 
 ## Notes
-
-## Links
-
-https://thesession.org/tunes/312#setting45001

--- a/content/tunes/the-lisnagun.md
+++ b/content/tunes/the-lisnagun.md
@@ -25,7 +25,3 @@ visibility: public
 ```
 
 ## Notes
-
-## Links
-
-https://thesession.org/tunes/3842#setting46053

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -802,6 +802,51 @@ a {
   }
 
   .set-entry__chart {
-    margin-left: 3.25rem;
+    margin: 0 0.5rem 0.5rem;
+  }
+
+  .tune-chart {
+    font-size: 0.625rem;
+    line-height: 1.5;
+    padding: 0.5rem 0.625rem;
+  }
+
+  .tune-chart__label {
+    font-size: 0.5625rem;
+    margin-bottom: 0.25rem;
+  }
+}
+
+/* Landscape phone: compact vertical spacing so two tunes fit in view */
+@media (max-height: 500px) and (min-width: 500px) {
+  .tune-chart {
+    line-height: 1.3;
+    padding: 0.25rem 0.625rem;
+    margin-bottom: 0;
+  }
+
+  .tune-chart__label {
+    font-size: 0.5625rem;
+    margin-bottom: 0.125rem;
+  }
+
+  .set-entry {
+    padding: 0.25rem 0.75rem;
+  }
+
+  .set-entry__chart {
+    margin-bottom: 0.25rem;
+  }
+
+  .set-row__header {
+    padding: 0.5rem 0.75rem;
+  }
+
+  .section-block {
+    margin-top: 1rem;
+  }
+
+  .section-block h2 {
+    margin-bottom: 0.375rem;
   }
 }

--- a/src/lib/content/load-corpus.test.ts
+++ b/src/lib/content/load-corpus.test.ts
@@ -38,15 +38,7 @@ describe("loadSessionbookCorpus", () => {
       mode: "Dorian",
       meter: "4/4",
       visibility: "public",
-      links: [
-        {
-          label: "The Session (setting 45009)",
-          href: "https://thesession.org/tunes/496#setting45009",
-          provider: "the-session",
-          theSessionTuneId: 496,
-          theSessionSettingId: 45009,
-        },
-      ],
+      links: [],
       versions: [
         {
           label: "Session default",

--- a/src/lib/content/repository.test.ts
+++ b/src/lib/content/repository.test.ts
@@ -25,12 +25,7 @@ describe("createContentRepository", () => {
         name: "Glen of Aherlow / Merry Blacksmith",
       },
     ]);
-    expect(glenOfAherlow?.theSessionLink).toMatchObject({
-      href: "https://thesession.org/tunes/496#setting45009",
-      provider: "the-session",
-      theSessionTuneId: 496,
-      theSessionSettingId: 45009,
-    });
+    expect(glenOfAherlow?.theSessionLink).toBeUndefined();
     expect(glenOfAherlow?.hasStructuredVersions).toBe(true);
     expect(glenOfAherlow?.versions[0]?.parts.map((part) => part.name)).toEqual([
       "A",


### PR DESCRIPTION
## Changes

### Session work data update
- Fix Fig for a Kiss A part chord (D→Bm) and alt label (Sub D Sub C)
- Remove inline links/notes moved to external sources
- Regenerate canonical content from session workbook

### Mobile chord chart responsiveness

**Portrait (≤640px):**
- Remove chart left margin — charts render full-width inside set cards
- Reduce chart font from 0.75rem → 0.625rem to fit ~50 chars on 375px phones
- Tighten chart padding and label sizing

**Landscape phone (≤500px height, ≥500px width):**
- Compress line-height 1.7 → 1.3 so two expanded tunes fit in viewport
- Compact entry row, header, and section spacing

---
_Will push additional commits as work continues._